### PR TITLE
Alias call first draft

### DIFF
--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -792,6 +792,7 @@ export class LuaTranspiler {
                 const funcName = node.expression.name.escapedText;
                 let funcHolder = tsEx.findMemberHolder(expType, funcName, this.checker);
 
+                // ===== EXPERIMENTAL https://github.com/Perryvw/TypescriptToLua/issues/56
                 if (ts.isParenthesizedExpression(node.expression.expression) 
                     && (ts.isAsExpression(node.expression.expression.expression) 
                      || ts.isTypeAssertion(node.expression.expression.expression))
@@ -801,6 +802,7 @@ export class LuaTranspiler {
                         funcHolder = castTypeNode.getText();
                     }
                 }
+                // ===== END EXPERIMENTAL
 
                 if (funcHolder === undefined) {
                     throw new TranspileError(`Could not find func ${funcName} on ${expType.symbol.name}`, node);

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -790,7 +790,17 @@ export class LuaTranspiler {
             // Include context parameter if present
             if (expType && expType.symbol) {
                 const funcName = node.expression.name.escapedText;
-                const funcHolder = tsEx.findMemberHolder(expType, funcName, this.checker);
+                let funcHolder = tsEx.findMemberHolder(expType, funcName, this.checker);
+
+                if (ts.isParenthesizedExpression(node.expression.expression) 
+                    && (ts.isAsExpression(node.expression.expression.expression) 
+                     || ts.isTypeAssertion(node.expression.expression.expression))
+                    && ts.isTypeReferenceNode(node.expression.expression.expression.type)) {
+                    const castTypeNode = node.expression.expression.expression.type;
+                    if (this.checker.getTypeFromTypeNode(castTypeNode).symbol.name == funcHolder) {
+                        funcHolder = castTypeNode.getText();
+                    }
+                }
 
                 if (funcHolder === undefined) {
                     throw new TranspileError(`Could not find func ${funcName} on ${expType.symbol.name}`, node);

--- a/test/integration/classInstanceCalls.spec.ts
+++ b/test/integration/classInstanceCalls.spec.ts
@@ -34,4 +34,16 @@ export class ClassInstanceCallTests {
         const lua = util.transpileFile("test/integration/testfiles/classInstanceCall4.ts");
         this.ExpectEqualToFile(lua, "test/integration/testfiles/classInstanceCall4.lua");
     }
+
+    @Test("aliasCastCall")
+    public aliasCastCall() {
+        const lua = util.transpileFile("test/integration/testfiles/aliasCastCall.ts");
+        this.ExpectEqualToFile(lua, "test/integration/testfiles/aliasCall.lua");
+    }
+
+    @Test("aliasAsCall")
+    public aliasAsCall() {
+        const lua = util.transpileFile("test/integration/testfiles/aliasAsCall.ts");
+        this.ExpectEqualToFile(lua, "test/integration/testfiles/aliasCall.lua");
+    }
 }

--- a/test/integration/testfiles/aliasAsCall.ts
+++ b/test/integration/testfiles/aliasAsCall.ts
@@ -1,0 +1,8 @@
+declare class ClassA {
+    myFunc();
+}
+declare type MyAlias = ClassA;
+declare var x: ClassA;
+
+x.myFunc();
+(x as MyAlias).myFunc();

--- a/test/integration/testfiles/aliasCall.lua
+++ b/test/integration/testfiles/aliasCall.lua
@@ -1,0 +1,2 @@
+ClassA.myFunc(x)
+MyAlias.myFunc((x))

--- a/test/integration/testfiles/aliasCastCall.ts
+++ b/test/integration/testfiles/aliasCastCall.ts
@@ -1,0 +1,8 @@
+declare class ClassA {
+    myFunc();
+}
+declare type MyAlias = ClassA;
+declare var x: ClassA;
+
+x.myFunc();
+(<MyAlias>x).myFunc();


### PR DESCRIPTION
To deal with dota client-sided API having different names for the same class. With this in the transpiler you could define aliases in the declarations, e.g.
```typescript
type C_DOTA_BaseNPC = CDOTA_BaseNPC;
``` 
Then an explicit cast would cause the transpiler to use the alias instead of the original class. For example
```typescript
unit.GetMana()                      ==>   CDOTA_BaseNPC.GetMana(unit)
(<C_DOTA_BaseNpc>unit).GetMana()    ==>   C_DOTA_BaseNPC.GetMana(unit)
```

Ideally this would automatically be done based on the value of `IsServer()`, but I currently see no way to do this in declarations while keeping the transpiler as generic as possible.