### PR TITLE
Fixed major bug with varargs/spread operator

### DIFF
--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1151,14 +1151,33 @@ export class LuaTranspiler {
 
         // Build parameter string
         const paramNames: string[] = [];
-        parameters.forEach((param) => {
-            paramNames.push((param.name as ts.Identifier).escapedText as string);
-        });
+
+        let spreadIdentifier = "";
+
+        // Only push parameter name to paramName array if it isn't a spread parameter
+        for (const param of parameters) {
+            const paramName = (param.name as ts.Identifier).escapedText as string;
+
+            // This parameter is a spread parameter (...param)
+            if (!param.dotDotDotToken) {
+                paramNames.push(paramName);
+            } else {
+                spreadIdentifier = paramName;
+                // Push the spread operator into the paramNames array
+                paramNames.push("...");
+            }
+        }
 
         // Build function header
         result += this.indent + this.accessPrefix(node) + `function ${methodName}(${paramNames.join(",")})\n`;
 
         this.pushIndent();
+
+        // Push spread operator here
+        if (spreadIdentifier !== "") {
+            result += `    local ${spreadIdentifier} = { ... }\n`;
+        }
+
         result += this.transpileBlock(body);
         this.popIndent();
 

--- a/test/translation/lua/varargs.lua
+++ b/test/translation/lua/varargs.lua
@@ -1,0 +1,3 @@
+function varargsFunction(a,...)
+    local b = { ... }
+end

--- a/test/translation/ts/varargs.ts
+++ b/test/translation/ts/varargs.ts
@@ -1,0 +1,1 @@
+function varargsFunction(a: string, ...b: string[]): void {}


### PR DESCRIPTION
A bug because usage of the spread operator transpiled without error into Lua, where the varargs array would be transpiled into only the first value of the varags; see [here](https://github.com/Perryvw/TypescriptToLua/issues/95).

Closes #95