### PR TITLE
Update isArrayType to include tuples

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -47,7 +47,7 @@ export class TSHelper {
 
     public static isArrayType(type: ts.Type, checker: ts.TypeChecker): boolean {
         const typeNode = checker.typeToTypeNode(type);
-        return typeNode && typeNode.kind === ts.SyntaxKind.ArrayType;
+        return typeNode && (typeNode.kind === ts.SyntaxKind.ArrayType || typeNode.kind === ts.SyntaxKind.TupleType);
     }
 
     public static isTupleType(type: ts.Type, checker: ts.TypeChecker): boolean {

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1158,7 +1158,7 @@ export class LuaTranspiler {
         const index = this.transpileExpression(node.argumentExpression);
 
         const type = this.checker.getTypeAtLocation(node.expression);
-        if (tsHelper.isArrayType(type, this.checker) || tsHelper.isTupleType(type, this.checker)) {
+        if (tsHelper.isArrayType(type, this.checker)) {
             return `${element}[${index}+1]`;
         } else if (tsHelper.isStringType(type)) {
             return `string.sub(${element},${index}+1,${index}+1)`;

--- a/test/translation/lua/tupleArrayUses.lua
+++ b/test/translation/lua/tupleArrayUses.lua
@@ -1,0 +1,8 @@
+for _, value in ipairs(tuple) do
+end
+TS_forEach(tuple, function(v)
+end
+)
+local num = tuple[1+1]
+
+local len = #tuple

--- a/test/translation/ts/tupleArrayUses.ts
+++ b/test/translation/ts/tupleArrayUses.ts
@@ -1,0 +1,8 @@
+// test cases where tuples are used as arrays
+declare const tuple: [string, number, boolean];
+
+// tslint:disable:no-empty no-unused-expression
+for (const value of tuple) {} // for-of loop
+tuple.forEach(v => {}); // Array.prototype.forEach
+const num = tuple[1]; // array access
+const len = tuple.length; // array length


### PR DESCRIPTION
Tuples are a type of array and have the same semantics, so this PR changes `isArrayType` to include tuples. This fixes a few issues when using tuples with for-of loops, `Array.prototype` methods, and so on. It also includes a test for these cases.