### PR TITLE
Fix unmatched ts/lua function signatures for Map and Set

### DIFF
--- a/dist/lualib/typescript.lua
+++ b/dist/lualib/typescript.lua
@@ -144,7 +144,7 @@ function Set.constructor(self, other)
 end
 function Set.add(self, item) self._items[item] = true end
 function Set.contains(self, item) return self._items[item] ~= nil end
-function Set.remove(self, item)
+function Set.delete(self, item)
     local contains = Set.contains(self, item)
     self._items[item] = nil
     return contains
@@ -180,9 +180,9 @@ function Map.constructor(self, other)
         end
     end
 end
-function Map.put(self, key, value) self._items[key] = value end
+function Map.set(self, key, value) self._items[key] = value end
 function Map.containsKey(self, key) return self._items[key] ~= nil end
-function Map.remove(self, key)
+function Map.delete(self, key)
     local contains = self.containsKey(self, key)
     self._items[key] = nil
     return contains

--- a/src/CommandLineParser.ts
+++ b/src/CommandLineParser.ts
@@ -31,7 +31,7 @@ const optionDeclarations: { [key: string]: yargs.Options } = {
     },
     luaTarget: {
         alias: "lt",
-        choices: ["JIT", "5.3"],
+        choices: ["JIT", "5.3", "5.2", "5.1"],
         default: "JIT",
         describe: "Specify Lua target version.",
         type: "string",

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1016,6 +1016,7 @@ export abstract class LuaTranspiler {
     }
 
     public transpilePropertyAccessExpression(node: ts.PropertyAccessExpression): string {
+        const callPath = this.transpileExpression(node.expression);
         const property = node.name.text;
 
         // Check for primitive types to override
@@ -1029,6 +1030,11 @@ export abstract class LuaTranspiler {
                     return this.transpileArrayProperty(node);
                 } else if (tsHelper.hasGetAccessor(node, this.checker)) {
                     return this.transpileGetAccessor(node);
+                } else if (property === "size" && type.symbol) {
+                    const symbolName = type.symbol.escapedName;
+                    if (symbolName === "Set" || symbolName === "Map") {
+                        return `${callPath}:count()`;
+                    }
                 }
         }
 
@@ -1042,7 +1048,6 @@ export abstract class LuaTranspiler {
             return this.transpileMathExpression(node.name);
         }
 
-        const callPath = this.transpileExpression(node.expression);
         return `${callPath}.${property}`;
     }
 


### PR DESCRIPTION
In TypeScript Map and Set use different function signatures against current implementation:

- `delete()` instead of `remove()`
- `set()` instead of `put()`
- `size` instead of `count()`