### PR TITLE
Support for single-character escape sequences

### DIFF
--- a/test/translation/lua/characterEscapeSequence.lua
+++ b/test/translation/lua/characterEscapeSequence.lua
@@ -14,3 +14,5 @@ local escapedCharsInDoubleQUotes = "\\ \0 \b \t \n \v \f \" \' \`"
 
 local escapedCharsInTemplateString = "\\ \0 \b \t \n \v \f \" \' \`"
 
+local nonEmptyTemplateString = "Level 0: \n\t "..tostring("Level 1: \n\t\t "..tostring("Level 3: \n\t\t\t "..tostring("Last level \n --").." \n --").." \n --").." \n --"
+

--- a/test/translation/lua/characterEscapeSequence.lua
+++ b/test/translation/lua/characterEscapeSequence.lua
@@ -1,0 +1,16 @@
+local quoteInDoubleQuotes = "\' \' \'"
+
+local quoteInTemplateString = "\' \' \'"
+
+local doubleQuoteInQuotes = "\" \" \""
+
+local doubleQuoteInDoubleQuotes = "\" \" \""
+
+local doubleQuoteInTemplateString = "\" \" \""
+
+local escapedCharsInQuotes = "\\ \0 \b \t \n \v \f \" \' \`"
+
+local escapedCharsInDoubleQUotes = "\\ \0 \b \t \n \v \f \" \' \`"
+
+local escapedCharsInTemplateString = "\\ \0 \b \t \n \v \f \" \' \`"
+

--- a/test/translation/ts/characterEscapeSequence.ts
+++ b/test/translation/ts/characterEscapeSequence.ts
@@ -8,3 +8,5 @@ let doubleQuoteInTemplateString = `" " "`;
 let escapedCharsInQuotes = '\\ \0 \b \t \n \v \f \" \' \`';
 let escapedCharsInDoubleQUotes = "\\ \0 \b \t \n \v \f \" \' \`";
 let escapedCharsInTemplateString = `\\ \0 \b \t \n \v \f \" \' \``;
+
+let nonEmptyTemplateString = `Level 0: \n\t ${`Level 1: \n\t\t ${`Level 3: \n\t\t\t ${'Last level \n --'} \n --`} \n --`} \n --`;

--- a/test/translation/ts/characterEscapeSequence.ts
+++ b/test/translation/ts/characterEscapeSequence.ts
@@ -1,0 +1,10 @@
+let quoteInDoubleQuotes = "' ' '";
+let quoteInTemplateString = `' ' '`;
+
+let doubleQuoteInQuotes = '" " "';
+let doubleQuoteInDoubleQuotes = "\" \" \"";
+let doubleQuoteInTemplateString = `" " "`;
+
+let escapedCharsInQuotes = '\\ \0 \b \t \n \v \f \" \' \`';
+let escapedCharsInDoubleQUotes = "\\ \0 \b \t \n \v \f \" \' \`";
+let escapedCharsInTemplateString = `\\ \0 \b \t \n \v \f \" \' \``;


### PR DESCRIPTION
With this update single-character escape sequences will be preserved, e.g.
```ts
let escapedCharsInQuotes = '\\ \0 \b \t \n \v \f \" \' \`';
```
Is transpiled to
```lua
local escapedCharsInQuotes = "\\ \0 \b \t \n \v \f \" \' \`"
```

Previously you had to double escape them, for example `"\n"` would have resulted in an actual linebreak in the transpiled lua code.
