### PR TITLE
Support for unary expressions in assignments

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -190,4 +190,12 @@ export class TSHelper {
 
         return [false, null];
     }
+
+    public static isUnaryAssignmentExpression(node: ts.Node): boolean {
+        return (
+            (ts.isPrefixUnaryExpression(node) || ts.isPostfixUnaryExpression(node)) &&
+            node.parent &&
+            node.parent.kind !== ts.SyntaxKind.ExpressionStatement
+        );
+    }
 }

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -792,10 +792,41 @@ export abstract class LuaTranspiler {
         }
     }
 
+    public transpileBinaryExpressionLeft(node: ts.BinaryExpression): [boolean, string] {
+        const lhs = this.transpileExpression(node.left, true);
+        let isUnary = false;
+        let result = lhs;
+        // When node.right is an assigning unary expression
+        // and node.left uses the same operand as node.right,
+        // the evaluation of node.left is wrapped in an anonymous function call
+        // to preserve order of operation (right will be transpiled to an anonymous function call)
+        // This is an edge case as "count = count++" is probably considered bad practice.
+        if (tsHelper.isUnaryAssignmentExpression(node.right)) {
+            let rightOperand: string;
+            if ((node.right as any).operand != null) {
+                rightOperand = this.transpileExpression((node.right as any).operand);
+            }
+
+            if (
+                lhs === rightOperand && (
+                    node.operatorToken.kind === ts.SyntaxKind.PlusToken ||
+                    node.operatorToken.kind === ts.SyntaxKind.MinusToken
+                )
+            ) {
+                isUnary = true;
+                result = this.transpileExpression(ts.createImmediatelyInvokedArrowFunction([
+                    ts.createReturn(node.left),
+                ]));
+            }
+        }
+
+        return [isUnary, result];
+    }
+
     public transpileBinaryExpression(node: ts.BinaryExpression, brackets?: boolean): string {
         // Transpile operands
-        const lhs = this.transpileExpression(node.left, true);
-        const rhs = this.transpileExpression(node.right, true);
+        const [isUnary, lhs] = this.transpileBinaryExpressionLeft(node);
+        const rhs = this.transpileExpression(node.right, isUnary);
 
         // Check if this is an assignment token, then handle accordingly
         const [isAssignment, operator] = tsHelper.isBinaryAssignmentToken(node.operatorToken.kind);
@@ -810,7 +841,7 @@ export abstract class LuaTranspiler {
 
         let result = "";
 
-        // Transpile Bitops
+         // Transpile Bitops
         switch (node.operatorToken.kind) {
             case ts.SyntaxKind.AmpersandToken:
             case ts.SyntaxKind.BarToken:
@@ -823,76 +854,76 @@ export abstract class LuaTranspiler {
 
         // Transpile operators
         if (result === "") {
-            switch (node.operatorToken.kind) {
-                case ts.SyntaxKind.AmpersandAmpersandToken:
-                    result = `${lhs} and ${rhs}`;
-                    break;
-                case ts.SyntaxKind.BarBarToken:
-                    result = `${lhs} or ${rhs}`;
-                    break;
-                case ts.SyntaxKind.PlusToken:
-                    // Replace string + with ..
-                    const typeLeft = this.checker.getTypeAtLocation(node.left);
-                    const typeRight = this.checker.getTypeAtLocation(node.right);
-                    if ((typeLeft.flags & ts.TypeFlags.String) || ts.isStringLiteral(node.left)
-                        ||  (typeRight.flags & ts.TypeFlags.String) || ts.isStringLiteral(node.right)) {
-                        return lhs + " .. " + rhs;
-                    }
-                    result = `${lhs}+${rhs}`;
-                    break;
-                case ts.SyntaxKind.MinusToken:
-                    result = `${lhs}-${rhs}`;
-                    break;
-                case ts.SyntaxKind.AsteriskToken:
-                    result = `${lhs}*${rhs}`;
-                    break;
-                case ts.SyntaxKind.AsteriskAsteriskToken:
-                    result = `${lhs}^${rhs}`;
-                    break;
-                case ts.SyntaxKind.SlashToken:
-                    result = `${lhs}/${rhs}`;
-                    break;
-                case ts.SyntaxKind.PercentToken:
-                    result = `${lhs}%${rhs}`;
-                    break;
-                case ts.SyntaxKind.GreaterThanToken:
-                    result = `${lhs}>${rhs}`;
-                    break;
-                case ts.SyntaxKind.GreaterThanEqualsToken:
-                    result = `${lhs}>=${rhs}`;
-                    break;
-                case ts.SyntaxKind.LessThanToken:
-                    result = `${lhs}<${rhs}`;
-                    break;
-                case ts.SyntaxKind.LessThanEqualsToken:
-                    result = `${lhs}<=${rhs}`;
-                    break;
-                case ts.SyntaxKind.EqualsToken:
-                    if (tsHelper.hasSetAccessor(node.left, this.checker)) {
-                        return this.transpileSetAccessor(node.left as ts.PropertyAccessExpression, rhs);
-                    }
+        switch (node.operatorToken.kind) {
+            case ts.SyntaxKind.AmpersandAmpersandToken:
+                result = `${lhs} and ${rhs}`;
+                break;
+            case ts.SyntaxKind.BarBarToken:
+                result = `${lhs} or ${rhs}`;
+                break;
+            case ts.SyntaxKind.PlusToken:
+                // Replace string + with ..
+                const typeLeft = this.checker.getTypeAtLocation(node.left);
+                const typeRight = this.checker.getTypeAtLocation(node.right);
+                if ((typeLeft.flags & ts.TypeFlags.String) || ts.isStringLiteral(node.left)
+                    ||  (typeRight.flags & ts.TypeFlags.String) || ts.isStringLiteral(node.right)) {
+                    return lhs + " .. " + rhs;
+                }
+                result = `${lhs}+${rhs}`;
+                break;
+            case ts.SyntaxKind.MinusToken:
+                result = `${lhs}-${rhs}`;
+                break;
+            case ts.SyntaxKind.AsteriskToken:
+                result = `${lhs}*${rhs}`;
+                break;
+            case ts.SyntaxKind.AsteriskAsteriskToken:
+                result = `${lhs}^${rhs}`;
+                break;
+            case ts.SyntaxKind.SlashToken:
+                result = `${lhs}/${rhs}`;
+                break;
+            case ts.SyntaxKind.PercentToken:
+                result = `${lhs}%${rhs}`;
+                break;
+            case ts.SyntaxKind.GreaterThanToken:
+                result = `${lhs}>${rhs}`;
+                break;
+            case ts.SyntaxKind.GreaterThanEqualsToken:
+                result = `${lhs}>=${rhs}`;
+                break;
+            case ts.SyntaxKind.LessThanToken:
+                result = `${lhs}<${rhs}`;
+                break;
+            case ts.SyntaxKind.LessThanEqualsToken:
+                result = `${lhs}<=${rhs}`;
+                break;
+            case ts.SyntaxKind.EqualsToken:
+                if (tsHelper.hasSetAccessor(node.left, this.checker)) {
+                    return this.transpileSetAccessor(node.left as ts.PropertyAccessExpression, rhs);
+                }
 
-                    result = `${lhs} = ${rhs}`;
-                    break;
-                case ts.SyntaxKind.EqualsEqualsToken:
-                case ts.SyntaxKind.EqualsEqualsEqualsToken:
-                    result = `${lhs}==${rhs}`;
-                    break;
-                case ts.SyntaxKind.ExclamationEqualsToken:
-                case ts.SyntaxKind.ExclamationEqualsEqualsToken:
-                    result = `${lhs}~=${rhs}`;
-                    break;
-                case ts.SyntaxKind.InKeyword:
-                    result = `${rhs}[${lhs}]~=nil`;
-                    break;
-                case ts.SyntaxKind.InstanceOfKeyword:
-                    result = this.transpileLuaLibFunction(LuaLibFeature.InstanceOf, lhs, rhs);
-                    break;
-                default:
-                    throw new TranspileError(
-                        "Unsupported binary operator kind: " + ts.tokenToString(node.operatorToken.kind),
-                        node
-                    );
+                result = `${lhs} = ${rhs}`;
+                break;
+            case ts.SyntaxKind.EqualsEqualsToken:
+            case ts.SyntaxKind.EqualsEqualsEqualsToken:
+                result = `${lhs}==${rhs}`;
+                break;
+            case ts.SyntaxKind.ExclamationEqualsToken:
+            case ts.SyntaxKind.ExclamationEqualsEqualsToken:
+                result = `${lhs}~=${rhs}`;
+                break;
+            case ts.SyntaxKind.InKeyword:
+                result = `${rhs}[${lhs}]~=nil`;
+                break;
+            case ts.SyntaxKind.InstanceOfKeyword:
+                result = this.transpileLuaLibFunction(LuaLibFeature.InstanceOf, lhs, rhs);
+                break;
+            default:
+                throw new TranspileError(
+                    "Unsupported binary operator kind: " + ts.tokenToString(node.operatorToken.kind),
+                    node
+                );
             }
         }
 
@@ -936,38 +967,112 @@ export abstract class LuaTranspiler {
                                             `function() return ${val1} end`, `function() return ${val2} end`);
     }
 
+    /** Transpiles a self-assigning unary expression (--var OR var-- OR ++var OR var++) */
+    public transpileSelfAssigningUnaryExpression(
+        node: ts.PrefixUnaryExpression | ts.PostfixUnaryExpression,
+        operator: ts.SyntaxKind.PlusToken | ts.SyntaxKind.MinusToken
+    ): string {
+        let expression: ts.Expression;
+        // @TODO "most likely" isn't a proper reason to do this
+        // If the node has a parent and it's not an Expression statement,
+        // the return value of the expression is most likely assigned to something.
+        // The operation has to be wrapped in an anonymous function call because lua
+        // doesn't support inline assignments.
+        const exemptWrapFunctionCall = [
+            ts.SyntaxKind.ExpressionStatement,
+            ts.SyntaxKind.ForStatement,
+        ];
+
+        if (node.parent && exemptWrapFunctionCall.indexOf(node.parent.kind) === -1) {
+            let returnIdentifier: ts.Identifier | ts.Expression;
+            const functionBody: ts.Statement[] = [
+                ts.createStatement(
+                    ts.createBinary(
+                        node.operand,
+                        ts.SyntaxKind.EqualsToken,
+                        ts.createBinary(node.operand, operator, ts.createLiteral(1))
+                    )
+                ),
+            ];
+
+            if (ts.isPostfixUnaryExpression(node)) {
+                // Name of the temp var is based on the operand's name to avoid collision
+                const tempVarName = `${this.transpileExpression(node.operand)}_before`;
+                // Add local variable storing the value before the operation, because:
+                // var++ / var-- is a special case where the return value of the expression
+                // is the value before the ++/-- operation
+                functionBody.unshift(ts.createVariableStatement(
+                    null,
+                    [ts.createVariableDeclaration(tempVarName, null, node.operand)]
+                ));
+
+                returnIdentifier = ts.createIdentifier(tempVarName);
+            } else if (ts.isPrefixUnaryExpression(node)) {
+                returnIdentifier = node.operand;
+            } else {
+                throw new TranspileError("Attempting to transpile non-unary node as unary", node);
+            }
+
+            functionBody.push(ts.createReturn(returnIdentifier));
+            expression = ts.createImmediatelyInvokedArrowFunction(functionBody);
+        } else {
+            expression = ts.createBinary(
+                node.operand,
+                ts.SyntaxKind.EqualsToken,
+                ts.createBinary(
+                    node.operand,
+                    operator,
+                    ts.createLiteral(1)
+                )
+            );
+        }
+
+        return this.transpileExpression(expression, false);
+    }
+
     public transpilePostfixUnaryExpression(node: ts.PostfixUnaryExpression): string {
-        const operand = this.transpileExpression(node.operand, true);
+        let operator: ts.BinaryOperator;
+
         switch (node.operator) {
             case ts.SyntaxKind.PlusPlusToken:
-                return `${operand}=${operand}+1`;
+                operator = ts.SyntaxKind.PlusToken;
+                break;
             case ts.SyntaxKind.MinusMinusToken:
-                return `${operand}=${operand}-1`;
+                operator = ts.SyntaxKind.MinusToken;
+                break;
             default:
-                const operator = tsHelper.enumName(node.operator, ts.SyntaxKind);
-                throw new TranspileError("Unsupported unary postfix: " + operator,
+                const operatorName = tsHelper.enumName(node.operator, ts.SyntaxKind);
+                throw new TranspileError("Unsupported unary postfix: " + operatorName,
                                          node);
         }
+
+        return this.transpileSelfAssigningUnaryExpression(node, operator);
     }
 
     public transpilePrefixUnaryExpression(node: ts.PrefixUnaryExpression): string {
         const operand = this.transpileExpression(node.operand, true);
+        let operator: ts.BinaryOperator;
+
         switch (node.operator) {
             case ts.SyntaxKind.TildeToken:
                 return this.transpileUnaryBitOperation(node, operand);
             case ts.SyntaxKind.PlusPlusToken:
-                return `${operand}=${operand}+1`;
+                operator = ts.SyntaxKind.PlusToken;
+                break;
             case ts.SyntaxKind.MinusMinusToken:
-                return `${operand}=${operand}-1`;
+                operator = ts.SyntaxKind.MinusToken;
+                break;
             case ts.SyntaxKind.ExclamationToken:
                 return `(not ${operand})`;
             case ts.SyntaxKind.MinusToken:
                 return `-${operand}`;
             default:
-                const operator = tsHelper.enumName(node.operator, ts.SyntaxKind);
-                throw new TranspileError("Unsupported unary prefix: " + operator,
+                const operatorName = tsHelper.enumName(node.operator, ts.SyntaxKind);
+                throw new TranspileError("Unsupported unary prefix: " + operatorName,
                                          node);
         }
+
+        return this.transpileSelfAssigningUnaryExpression(node, operator);
     }
 
     public transpileNewExpression(node: ts.NewExpression): string {

--- a/test/translation/lua/continue.lua
+++ b/test/translation/lua/continue.lua
@@ -6,5 +6,5 @@ while(i<10) do
         end
     end
     ::__continue0::
-    i=i+1
+    i = i+1
 end

--- a/test/translation/lua/continueConcurrent.lua
+++ b/test/translation/lua/continueConcurrent.lua
@@ -9,5 +9,5 @@ while(i<10) do
         end
     end
     ::__continue0::
-    i=i+1
+    i = i+1
 end

--- a/test/translation/lua/continueNested.lua
+++ b/test/translation/lua/continueNested.lua
@@ -12,9 +12,9 @@ while(i<5) do
                 end
             end
             ::__continue1::
-            j=j+1
+            j = j+1
         end
     end
     ::__continue0::
-    i=i+1
+    i = i+1
 end

--- a/test/translation/lua/continueNestedConcurrent.lua
+++ b/test/translation/lua/continueNestedConcurrent.lua
@@ -12,12 +12,12 @@ while(i<5) do
                 end
             end
             ::__continue1::
-            j=j+1
+            j = j+1
         end
         if i==4 then
             goto __continue0
         end
     end
     ::__continue0::
-    i=i+1
+    i = i+1
 end

--- a/test/translation/lua/do.lua
+++ b/test/translation/lua/do.lua
@@ -2,7 +2,7 @@ local e = 10
 
 repeat
     do
-        e=e-1
+        e = e-1
     end
     ::__continue0::
 until not (e>0)

--- a/test/translation/lua/for.lua
+++ b/test/translation/lua/for.lua
@@ -3,5 +3,5 @@ while(i<=100) do
     do
     end
     ::__continue0::
-    i=i+1
+    i = i+1
 end

--- a/test/translation/lua/getSetAccessors.lua
+++ b/test/translation/lua/getSetAccessors.lua
@@ -11,7 +11,7 @@ function MyClass.get__field(self)
     return self._field+4
 end
 function MyClass.set__field(self,v)
-    self._field = (v*2)
+    self._field = v*2
 end
 local instance = MyClass.new(true)
 

--- a/test/translation/lua/unary.lua
+++ b/test/translation/lua/unary.lua
@@ -1,0 +1,50 @@
+local count01 = 0
+
+count01 = count01+1
+local count02 = (function()
+    local count01_before = count01
+
+    count01 = count01+1
+    return count01_before
+end
+)()
+
+count01 = (function()
+    local count01_before = count01
+
+    count01 = count01+1
+    return count01_before
+end
+)()
+count01 = (function()
+    return count01
+end
+)()+(function()
+    local count01_before = count01
+
+    count01 = count01+1
+    return count01_before
+end
+)()
+local count03 = 0
+
+count03 = count03-1
+local count04 = (function()
+    count03 = count03-1
+    return count03
+end
+)()
+
+count03 = (function()
+    count03 = count03-1
+    return count03
+end
+)()
+count03 = (function()
+    return count03
+end
+)()+(function()
+    count03 = count03-1
+    return count03
+end
+)()

--- a/test/translation/lua/while.lua
+++ b/test/translation/lua/while.lua
@@ -2,7 +2,7 @@ local d = 10
 
 while d>0 do
     do
-        d=d-1
+        d = d-1
     end
     ::__continue0::
 end

--- a/test/translation/ts/unary.ts
+++ b/test/translation/ts/unary.ts
@@ -1,0 +1,28 @@
+let count01 = 0;
+
+// Pure unary
+count01++;
+
+// Assignment
+let count02 = count01++;
+
+// Self-assignment
+count01 = count01++;
+
+// Self-referencing assignment
+count01 += count01++;
+
+
+let count03 = 0;
+
+// Pure unary
+--count03;
+
+// Assignment
+let count04 = --count03;
+
+// Self-assignment
+count03 = --count03;
+
+// Self-referencing assignment
+count03 += --count03;

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -6,10 +6,10 @@ import * as util from "../src/util";
 
 export class ExpressionTests {
 
-    @TestCase("i++", "i=i+1")
-    @TestCase("++i", "i=i+1")
-    @TestCase("i--", "i=i-1")
-    @TestCase("--i", "i=i-1")
+    @TestCase("i++", "i = i+1")
+    @TestCase("++i", "i = i+1")
+    @TestCase("i--", "i = i-1")
+    @TestCase("--i", "i = i-1")
     @TestCase("!a", "(not a)")
     @TestCase("-a", "-a")
     @TestCase("delete tbl['test']", "tbl[\"test\"]=nil")
@@ -175,7 +175,7 @@ export class ExpressionTests {
     @TestCase("-1+1", "-1+1")
     @TestCase("1*30+4", "(1*30)+4")
     @TestCase("1*(3+4)", "1*(3+4)")
-    @TestCase("1*(3+4*2)", "1*(3+(4*2))")
+    @TestCase("1*(3+4*2)", "1*(3+4*2)")
     @Test("Binary expressions ordering parentheses")
     public binaryParentheses(input: string, lua: string) {
         Expect(util.transpileString(input)).toBe(lua);


### PR DESCRIPTION
**TS**
```ts
let count = 0;
count++;
--count;

let count01 = count++;
let count02 = --count;

// Self-referencing operations
let count03 = count02 + count02++;
let count04 = count02 + --count02;
// Non-self-referencing
let count05 = count02 + ++count03;
```
**Lua**
```lua
local count = 0

count = count+1
count = count-1
local count01 = (function() local count_before = count; count = count+1; return count_before end)()

local count02 = (function() count = count-1; return count end)()

-- Self-referencing operations
local count03 = (function() return count02 end)()+(function() local count02_before = count02; count02 = count02+1; return count02_before end)()
local count04 = (function() return count02 end)()+(function() count02 = count02-1; return count02 end)()
--  Non-self-referencing
local count05 = count02+(function() count03 = count03+1; return count03 end)()
```

### Note!

Does not add support for chained assignments, e.g. `let count = count03 += 3` . (has to be implemented at some point, hopefully)
