### PR TITLE
Add support for block statements

### DIFF
--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -250,7 +250,7 @@ export abstract class LuaTranspiler {
             }
         }
 
-        result += "end";
+        result += "end\n";
         return result;
     }
 

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -240,6 +240,20 @@ export abstract class LuaTranspiler {
         return result;
     }
 
+    // Transpile a block statement
+    public transpileBlockStatement(block: ts.Block): string {
+        let result = "do\n";
+        for (const statement of block.statements) {
+            result += this.transpileNode(statement);
+            if (ts.isReturnStatement(statement)) {
+                break;
+            }
+        }
+
+        result += "end";
+        return result;
+    }
+
     // Transpile a node of unknown kind.
     public transpileNode(node: ts.Node): string {
         // Ignore declarations
@@ -293,6 +307,8 @@ export abstract class LuaTranspiler {
             case ts.SyntaxKind.EndOfFileToken:
                 // Ignore these
                 return "";
+            case ts.SyntaxKind.Block:
+                return this.transpileBlockStatement(node as ts.Block);
             default:
                 return this.indent + this.transpileExpression(node) + "\n";
         }


### PR DESCRIPTION
I hacked in a quick change to support block statements. Lemme know if I should add tests!

TS:

```ts
{
  const a = 1 + 2
  do_something(a)
}
```

Lua:

```lua
do
  local a = 1 + 2
  do_something(a)
end
```