### PR TITLE
Escape reserved identifier instead of throwing an exception

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -40,9 +40,6 @@ export class TSTLErrors {
     public static InvalidThrowExpression = (node: ts.Node) =>
         new TranspileError(`Invalid throw expression, only strings can be thrown.`, node)
 
-    public static KeywordIdentifier = (node: ts.Identifier) =>
-        new TranspileError(`Cannot use Lua keyword ${node.escapedText} as identifier.`, node)
-
     public static MissingClassName = (node: ts.Node) =>
         new TranspileError(`Class declarations must have a name.`, node)
 

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -56,7 +56,8 @@ export abstract class LuaTranspiler {
         ["and", "break", "do", "else", "elseif",
          "end", "false", "for", "function", "if",
          "in", "local", "nil", "not", "or",
-         "repeat", "return", "then", "until", "while"]);
+         "repeat", "return", "then", "until", "while",
+         "type", "table"]);
 
     public indent: string;
     public checker: ts.TypeChecker;
@@ -1360,7 +1361,7 @@ export abstract class LuaTranspiler {
         }
 
         if (this.luaKeywords.has(escapedText)) {
-            throw TSTLErrors.KeywordIdentifier(identifier);
+            return `___${escapedText}`;
         }
 
         return escapedText;

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -180,9 +180,14 @@ export class AssignmentTests {
     @TestCase("repeat")
     @TestCase("then")
     @TestCase("until")
-    @Test("Keyword identifier error")
-    public keywordIdentifierError(identifier: string): void {
-        Expect(() => util.transpileString(`const ${identifier} = 3;`))
-            .toThrowError(TranspileError, `Cannot use Lua keyword ${identifier} as identifier.`);
+    @TestCase("type")
+    @TestCase("table")
+    @Test("Keyword identifier escaping")
+    public keywordIdentifierEscaping(identifier: string): void {
+        const lua = util.transpileString(`const ${identifier} = 3; return ${identifier};`);
+
+        const result = util.executeLua(lua);
+
+        Expect(result).toBe(3);
     }
 }


### PR DESCRIPTION
Instead of throwing an error when using lua keywords as identifiers, we just escape them with some underscores so code does not unnecessarily breaks.

Should fix #188 