### PR TITLE
Method declarations now use custom decorators

### DIFF
--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -685,7 +685,8 @@ export abstract class LuaTranspiler {
         if (node.expression) {
             // If parent function is a TupleReturn function
             // and return expression is an array literal, leave out brackets.
-            const declaration = tsHelper.findFirstNodeAbove(node, ts.isFunctionDeclaration);
+            const declaration = tsHelper.findFirstNodeAbove(node, ts.isFunctionDeclaration)
+                || tsHelper.findFirstNodeAbove(node, ts.isMethodDeclaration);
             let isTupleReturn = false;
             if (declaration) {
                 const decorators = tsHelper.getCustomDecorators(


### PR DESCRIPTION
For #196 

The following code
https://github.com/Perryvw/TypescriptToLua/blob/50e6cb59691daff5dad40613fca332e78eaad754/src/Transpiler.ts#L688
Only picks up function declarations, not method declarations.

Adding `|| tsHelper.findFirstNodeAbove(node, ts.isMethodDeclaration)` to the end allows it to pick up static and dynamic methods as well.

This allows the `!TupleReturn` decorator to work on class methods
