### PR TITLE
-added support for block expression

### DIFF
--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -800,6 +800,11 @@ export abstract class LuaTranspiler {
                 return "";
             case ts.SyntaxKind.SpreadElement:
                 return this.transpileSpreadElement(node as ts.SpreadElement);
+            case ts.SyntaxKind.Block:
+                this.pushIndent();
+                const ret = "do \n" + this.transpileBlock(node as ts.Block) + "end\n";
+                this.popIndent();
+                return ret;
             default:
                 throw TSTLErrors.UnsupportedKind("expression", node.kind, node);
         }

--- a/test/compiler/errorreport.spec.ts
+++ b/test/compiler/errorreport.spec.ts
@@ -11,7 +11,6 @@ export class CompilerErrorReportTests {
 
     @TestCase("Encountered error parsing file: Default Imports are not supported, please use named imports instead!\n",
               "default_import.ts")
-    @TestCase("Encountered error parsing file: Unsupported expression kind: Block\n", "invalid_syntax.ts")
     @Test("Compile project")
     public compileProject(errorMsg: string, ...fileNames: string[]) {
         fileNames = fileNames.map((file) => path.resolve(__dirname, "testfiles", file));

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -285,6 +285,11 @@ export class ExpressionTests {
         Expect(result).toBe(expected);
     }
 
+    @Test("Block expression")
+    public blockExpresion(): void {
+        const result = util.transpileAndExecute(`let a = 4; {let a = 42; } return a;`);
+        Expect(result).toBe(4);
+    }
     // ====================================
     // Test expected errors
     // ====================================


### PR DESCRIPTION
A duplicate of #168 but hopefully mergeable. 
The only issue I ran into is that invalid_syntax.ts relies on the compiler throwing an error on block statements. Ideally it would need to test with a different unsupported statement, but not sure what to use.