### PR TITLE
Declaration Merging Fix

### DIFF
--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1131,7 +1131,9 @@ export abstract class LuaTranspiler {
         // Get the type of the function
         const functionType = this.checker.getTypeAtLocation(node.expression);
         // Don't replace . with : for namespaces or functions defined as properties with lambdas
-        if (functionType.symbol && !(functionType.symbol.flags & ts.SymbolFlags.Method)) {
+        if ((functionType.symbol && !(functionType.symbol.flags & ts.SymbolFlags.Method))
+            // Check explicitly for method calls on 'this', since they don't have the Method flag set
+            || (node.expression.expression.kind === ts.SyntaxKind.ThisType)) {
             callPath = this.transpileExpression(node.expression);
             params = this.transpileArguments(node.arguments);
             return `${callPath}(${params})`;

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1131,9 +1131,9 @@ export abstract class LuaTranspiler {
         // Get the type of the function
         const functionType = this.checker.getTypeAtLocation(node.expression);
         // Don't replace . with : for namespaces
-        if ((ownerType.symbol && (ownerType.symbol.flags & ts.SymbolFlags.Namespace))
+        if ((functionType.symbol && (!(functionType.symbol.flags & ts.SymbolFlags.Method)
             // If function is defined as property with lambda type use . instead of :
-            || (functionType.symbol && (functionType.symbol.flags & ts.SymbolFlags.TypeLiteral))) {
+            || (functionType.symbol.flags & ts.SymbolFlags.TypeLiteral)))) {
             callPath = this.transpileExpression(node.expression);
             params = this.transpileArguments(node.arguments);
             return `${callPath}(${params})`;

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1130,10 +1130,8 @@ export abstract class LuaTranspiler {
 
         // Get the type of the function
         const functionType = this.checker.getTypeAtLocation(node.expression);
-        // Don't replace . with : for namespaces
-        if ((functionType.symbol && (!(functionType.symbol.flags & ts.SymbolFlags.Method)
-            // If function is defined as property with lambda type use . instead of :
-            || (functionType.symbol.flags & ts.SymbolFlags.TypeLiteral)))) {
+        // Don't replace . with : for namespaces or functions defined as properties with lambdas
+        if (functionType.symbol && !(functionType.symbol.flags & ts.SymbolFlags.Method)) {
             callPath = this.transpileExpression(node.expression);
             params = this.transpileArguments(node.arguments);
             return `${callPath}(${params})`;

--- a/test/translation/lua/namespaceMerge.lua
+++ b/test/translation/lua/namespaceMerge.lua
@@ -1,0 +1,4 @@
+local mergedClass = MergedClass.new(true);
+mergedClass:method();
+mergedClass.propertyFunc();
+MergedClass.namespaceFunc();

--- a/test/translation/lua/namespaceMerge.lua
+++ b/test/translation/lua/namespaceMerge.lua
@@ -1,4 +1,34 @@
+MergedClass = MergedClass or {}
+MergedClass.__index = MergedClass
+function MergedClass.new(construct, ...)
+    local instance = setmetatable({}, MergedClass)
+    instance.propertyFunc = function()
+end
+
+    if construct and MergedClass.constructor then MergedClass.constructor(instance, ...) end
+    return instance
+end
+function MergedClass.constructor(self)
+end
+function MergedClass.staticMethodA(self)
+end
+function MergedClass.staticMethodB(self)
+    self:staticMethodA();
+end
+function MergedClass.methodA(self)
+end
+function MergedClass.methodB(self)
+    self:methodA();
+    self.propertyFunc();
+end
+MergedClass = MergedClass or {}
+do
+    local function namespaceFunc()
+    end
+    MergedClass.namespaceFunc = namespaceFunc
+end
 local mergedClass = MergedClass.new(true);
-mergedClass:method();
+mergedClass:methodB();
 mergedClass.propertyFunc();
+MergedClass:staticMethodB();
 MergedClass.namespaceFunc();

--- a/test/translation/ts/namespaceMerge.ts
+++ b/test/translation/ts/namespaceMerge.ts
@@ -1,0 +1,11 @@
+declare class MergedClass {
+    public propertyFunc: () => void;
+    public method(): void;
+}
+declare namespace MergedClass {
+    export function namespaceFunc(): void;
+}
+const mergedClass = new MergedClass();
+mergedClass.method();
+mergedClass.propertyFunc();
+MergedClass.namespaceFunc();

--- a/test/translation/ts/namespaceMerge.ts
+++ b/test/translation/ts/namespaceMerge.ts
@@ -1,11 +1,24 @@
-declare class MergedClass {
-    public propertyFunc: () => void;
-    public method(): void;
+class MergedClass {
+    public static staticMethodA(): void {}
+    public static staticMethodB(): void {
+        this.staticMethodA();
+    }
+
+    public propertyFunc: () => void = () => {};
+
+    public methodA(): void {}
+    public methodB(): void {
+        this.methodA();
+        this.propertyFunc();
+    }
 }
-declare namespace MergedClass {
-    export function namespaceFunc(): void;
+
+namespace MergedClass {
+    export function namespaceFunc(): void {}
 }
+
 const mergedClass = new MergedClass();
-mergedClass.method();
+mergedClass.methodB();
 mergedClass.propertyFunc();
+MergedClass.staticMethodB();
 MergedClass.namespaceFunc();


### PR DESCRIPTION
Modified logic determining if a method call should use dot instead of colon so that calls to methods on class types that are merged with a namespace will correctly use a colon.

Note that the separate check for property-style functions is also covered by this alternate logic so I removed it.

fixes #207