### PR TITLE
TupleReturn Fix

### DIFF
--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1077,10 +1077,11 @@ export abstract class LuaTranspiler {
 
         const isTupleReturn = tsHelper.isTupleReturnCall(node, this.checker);
         const isInDestructingAssignment = tsHelper.isInDestructingAssignment(node);
+        const returnValueIsUsed = node.parent && !ts.isExpressionStatement(node.parent);
 
         if (ts.isPropertyAccessExpression(node.expression)) {
             const result = this.transpilePropertyCall(node);
-            return isTupleReturn && !isInDestructingAssignment ? `({ ${result} })` : result;
+            return isTupleReturn && !isInDestructingAssignment && returnValueIsUsed ? `({ ${result} })` : result;
         }
 
         // Handle super calls properly
@@ -1092,7 +1093,8 @@ export abstract class LuaTranspiler {
 
         callPath = this.transpileExpression(node.expression);
         params = this.transpileArguments(node.arguments);
-        return isTupleReturn && !isInDestructingAssignment ? `({ ${callPath}(${params}) })` : `${callPath}(${params})`;
+        return isTupleReturn && !isInDestructingAssignment && returnValueIsUsed
+            ? `({ ${callPath}(${params}) })` : `${callPath}(${params})`;
     }
 
     public transpilePropertyCall(node: ts.CallExpression): string {

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -895,11 +895,14 @@ export abstract class LuaTranspiler {
                         return this.transpileSetAccessor(node.left as ts.PropertyAccessExpression, rhs);
                     }
 
-                    if (tsHelper.isTupleReturnCall(node.right, this.checker)
-                    && ts.isArrayLiteralExpression(node.left)) {
+                    if (ts.isArrayLiteralExpression(node.left)) {
                         // Destructing assignment
                         const vars = node.left.elements.map(e => this.transpileExpression(e)).join(",");
-                        return `${vars} = ${rhs}`;
+                        if (tsHelper.isTupleReturnCall(node.right, this.checker)) {
+                            return `${vars} = ${rhs}`;
+                        } else {
+                            return `${vars} = ${this.transpileDestructingAssignmentValue(node.right)}`;
+                        }
                     }
 
                     result = `${lhs} = ${rhs}`;

--- a/test/translation/lua/tupleReturn.lua
+++ b/test/translation/lua/tupleReturn.lua
@@ -1,0 +1,12 @@
+tupleReturn();
+noTupleReturn();
+local a,b=tupleReturn();
+local c,d=table.unpack(noTupleReturn());
+a,b = tupleReturn();
+c,d = table.unpack(noTupleReturn());
+local e = ({ tupleReturn() });
+local f = noTupleReturn();
+e = ({ tupleReturn() });
+f = noTupleReturn();
+foo(({ tupleReturn() }));
+foo(noTupleReturn());

--- a/test/translation/ts/tupleReturn.ts
+++ b/test/translation/ts/tupleReturn.ts
@@ -1,0 +1,16 @@
+/** !TupleReturn */
+declare function tupleReturn(): [number, string];
+declare function noTupleReturn(): [number, string];
+declare function foo(a: [number, string]): void;
+tupleReturn();
+noTupleReturn();
+let [a, b] = tupleReturn();
+let [c, d] = noTupleReturn();
+[a, b] = tupleReturn();
+[c, d] = noTupleReturn();
+let e = tupleReturn();
+let f = noTupleReturn();
+e = tupleReturn();
+f = noTupleReturn();
+foo(tupleReturn());
+foo(noTupleReturn());


### PR DESCRIPTION
This fixes #205 by checking if the return value is used on a TupleReturn call before wrapping it in a table.

It also fixes an issue I found similar to #200 where destructuring into existing vars from NON-TupleReturn calls resulted in invalid lua:
```ts
declare function foo(): [string, number];
let [s, n] = foo();
[s, n] = foo();
```
```lua
local s,n=foo();
{s,n}=foo();
```

I've added a tupleReturn translation test to check for both of these and other tuple-return related cases.

Sorry for the combo-PR: I wanted to get both fixes in the test.