### PR TITLE
Array union fix

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -74,7 +74,7 @@ export class TSHelper {
     }
 
     public static isArrayType(type: ts.Type, checker: ts.TypeChecker): boolean {
-        const typeNode = checker.typeToTypeNode(type);
+        const typeNode = checker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias);
         return typeNode && this.isArrayTypeNode(typeNode);
     }
 

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -66,9 +66,16 @@ export class TSHelper {
             || (type.flags & ts.TypeFlags.StringLiteral) !== 0;
     }
 
+    public static isArrayTypeNode(typeNode: ts.TypeNode): boolean {
+        return typeNode.kind === ts.SyntaxKind.ArrayType
+            || typeNode.kind === ts.SyntaxKind.TupleType
+            || ((typeNode.kind === ts.SyntaxKind.UnionType || typeNode.kind === ts.SyntaxKind.IntersectionType)
+                && (typeNode as ts.UnionOrIntersectionTypeNode).types.some(this.isArrayTypeNode));
+    }
+
     public static isArrayType(type: ts.Type, checker: ts.TypeChecker): boolean {
         const typeNode = checker.typeToTypeNode(type);
-        return typeNode && (typeNode.kind === ts.SyntaxKind.ArrayType || typeNode.kind === ts.SyntaxKind.TupleType);
+        return typeNode && this.isArrayTypeNode(typeNode);
     }
 
     public static isTupleReturnCall(node: ts.Node, checker: ts.TypeChecker): boolean {

--- a/test/unit/array.spec.ts
+++ b/test/unit/array.spec.ts
@@ -1,0 +1,41 @@
+import { Expect, Test, TestCase } from "alsatian";
+import * as util from "../src/util";
+
+export class ArrayTests {
+    @Test("Array access")
+    public arrayAccess(): void {
+        const lua = util.transpileString(
+            `const arr: number[] = [3,5,1];
+            return arr[1];`
+        );
+        const result = util.executeLua(lua);
+        Expect(result).toBe(5);
+    }
+
+    @Test("Array union access")
+    public arrayUnionAccess(): void {
+        const lua = util.transpileString(
+            `function makeArray(): number[] | string[] { return [3,5,1]; }
+            const arr = makeArray();
+            return arr[1];`
+        );
+        const result = util.executeLua(lua);
+        Expect(result).toBe(5);
+    }
+
+    @Test("Array intersection access")
+    public arrayIntersectionAccess(): void {
+        const lua = util.transpileString(
+            `type I = number[] & {foo: string};
+            function makeArray(): I {
+                let t = [3,5,1];
+                (t as I).foo = "bar";
+                return (t as I);
+            }
+            const arr = makeArray();
+            return arr[1];`
+        );
+        const result = util.executeLua(lua);
+        Expect(result).toBe(5);
+    }
+}

--- a/test/unit/tuples.spec.ts
+++ b/test/unit/tuples.spec.ts
@@ -51,6 +51,33 @@ export class TupleTests {
         Expect(result).toBe(5);
     }
 
+    @Test("Tuple union access")
+    public tupleUnionAccess(): void {
+        const lua = util.transpileString(
+            `function makeTuple(): [number, number, number] | [string, string, string] { return [3,5,1]; }
+            const tuple = makeTuple();
+            return tuple[1];`
+        );
+        const result = util.executeLua(lua);
+        Expect(result).toBe(5);
+    }
+
+    @Test("Tuple intersection access")
+    public tupleIntersectionAccess(): void {
+        const lua = util.transpileString(
+            `type I = [number, number, number] & {foo: string};
+            function makeTuple(): I {
+                let t = [3,5,1];
+                (t as I).foo = "bar";
+                return (t as I);
+            }
+            const tuple = makeTuple();
+            return tuple[1];`
+        );
+        const result = util.executeLua(lua);
+        Expect(result).toBe(5);
+    }
+
     @Test("Tuple Destruct")
     public tupleDestruct(): void {
         // Transpile


### PR DESCRIPTION
fixes #242 

Updated array check to allow unions and intersections that include an array type.

The one edge case I've seen is an intersection of an array type and an object type that defines numeric keys:
```ts
declare function foo(): string[] & {[0]: number, [1]: number};
let a = foo();
let b = a[0];
```
With this change, the index will get a +1. Whether it should or not is a bit ambiguous to me.
