### PR TITLE
WIP Upgraded to TS 3.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3883,9 +3883,9 @@
             "optional": true
         },
         "typescript": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-            "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.3.tgz",
+            "integrity": "sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA=="
         },
         "urlgrey": {
             "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "node": ">=8.5.0"
     },
     "dependencies": {
-        "typescript": "2.9.2",
+        "typescript": "^3.1.3",
         "yargs": "^12.0.1"
     },
     "devDependencies": {

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -153,7 +153,8 @@ function emitFilesAndReportErrors(program: ts.Program): number {
     return 0;
 }
 
-const libSource = fs.readFileSync(path.join(path.dirname(require.resolve("typescript")), "lib.es6.d.ts")).toString();
+const libSource = fs.readFileSync(path.join(path.dirname(require.resolve("typescript")), "lib.es5.d.ts")).toString()
+    + fs.readFileSync(path.join(path.dirname(require.resolve("typescript")), "lib.es2015.collection.d.ts")).toString();
 
 export function transpileString(str: string,
                                 options: CompilerOptions = {
@@ -165,7 +166,7 @@ export function transpileString(str: string,
         fileExists: (fileName): boolean => true,
         getCanonicalFileName: fileName => fileName,
         getCurrentDirectory: () => "",
-        getDefaultLibFileName: () => "lib.es6.d.ts",
+        getDefaultLibFileName: () => "lib.es5.d.ts",
         getDirectories: () => [],
         getNewLine: () => "\n",
 
@@ -173,7 +174,7 @@ export function transpileString(str: string,
             if (filename === "file.ts") {
                 return ts.createSourceFile(filename, str, ts.ScriptTarget.Latest, false);
             }
-            if (filename === "lib.es6.d.ts") {
+            if (filename === "lib.es5.d.ts") {
                 return ts.createSourceFile(filename, libSource, ts.ScriptTarget.Latest, false);
             }
             return undefined;
@@ -190,19 +191,6 @@ export function transpileString(str: string,
     const result = createTranspiler(program.getTypeChecker(),
                                     options,
                                     program.getSourceFile("file.ts")).transpileSourceFile();
-    return result.trim();
-}
-
-export function transpileFile(filePath: string): string {
-    const program = ts.createProgram([filePath], {});
-    const checker = program.getTypeChecker();
-
-    // Output errors
-    const diagnostics = ts.getPreEmitDiagnostics(program).filter(diag => diag.code !== 6054);
-    diagnostics.forEach(diagnostic => console.log(`${ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")}`));
-
-    const options: ts.CompilerOptions = { luaLibImport: "none" };
-    const result = createTranspiler(checker, options, program.getSourceFile(filePath)).transpileSourceFile();
     return result.trim();
 }
 

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -47,9 +47,8 @@ export class TSHelper {
         if (sourceFile) {
             // Vanilla ts flags files as external module if they have an import or
             // export statement, we only check for export statements
-            // TODO will break in 3.x
             return sourceFile.statements.some(statement =>
-                (ts.getCombinedModifierFlags(statement) & ts.ModifierFlags.Export) !== 0
+                (ts.getCombinedModifierFlags(statement as any as ts.Declaration) & ts.ModifierFlags.Export) !== 0
                 || statement.kind === ts.SyntaxKind.ExportAssignment
                 || statement.kind === ts.SyntaxKind.ExportDeclaration);
         }

--- a/src/tstl.ts
+++ b/src/tstl.ts
@@ -9,7 +9,6 @@ export {
 export {
     compile,
     compileFilesWithOptions,
-    transpileFile,
     transpileString,
     watchWithOptions
 } from "./Compiler";


### PR DESCRIPTION
Fixed issue with es6 lib (Microsoft/TypeScript/issues/27874) for now by using es5 combined with es6 collections

We still should  wait until MS resolves that bug.
Because tstl projects using ES6 will break.