### PR TITLE
Object literal method declaration support

### DIFF
--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1861,6 +1861,9 @@ export abstract class LuaTranspiler {
                 properties.push(`${name} = ${expression}`);
             } else if (ts.isShorthandPropertyAssignment(element)) {
                 properties.push(`${name} = ${name}`);
+            } else if (ts.isMethodDeclaration(element)) {
+                const expression = this.transpileFunctionExpression(element);
+                properties.push(`${name} = ${expression}`);
             } else {
                 throw TSTLErrors.UnsupportedKind("object literal element", element.kind, node);
             }
@@ -1869,9 +1872,12 @@ export abstract class LuaTranspiler {
         return "{" + properties.join(",") + "}";
     }
 
-    public transpileFunctionExpression(node: ts.ArrowFunction): string {
+    public transpileFunctionExpression(node: ts.FunctionLikeDeclaration): string {
         // Build parameter string
         const paramNames: string[] = [];
+        if (ts.isMethodDeclaration(node)) {
+            paramNames.push("self");
+        }
         node.parameters.forEach(param => {
             paramNames.push(this.transpileIdentifier(param.name as ts.Identifier));
         });

--- a/test/unit/functions.spec.ts
+++ b/test/unit/functions.spec.ts
@@ -282,4 +282,11 @@ export class FunctionTests {
 
         Expect(result).toBe("function");
     }
+
+    @Test("Object method declaration")
+    public objectMethodDeclaration(): void {
+        const result = util.transpileAndExecute(
+            `let o = { m(i: number): number { return i * i; } }; return o.m(3);`);
+        Expect(result).toBe(9);
+    }
 }

--- a/test/unit/functions.spec.ts
+++ b/test/unit/functions.spec.ts
@@ -286,7 +286,7 @@ export class FunctionTests {
     @Test("Object method declaration")
     public objectMethodDeclaration(): void {
         const result = util.transpileAndExecute(
-            `let o = { m(i: number): number { return i * i; } }; return o.m(3);`);
-        Expect(result).toBe(9);
+            `let o = { v: 4, m(i: number): number { return this.v * i; } }; return o.m(3);`);
+        Expect(result).toBe(12);
     }
 }


### PR DESCRIPTION
Currently, object literal methods are not supported:
```ts
const foo = {
    bar(): string { return "foobar"; } //error: Unsupported object literal element kind: MethodDeclaration
};
```

This PR adds support for them.