### PR TITLE
converting 'else if' statements to lua 'elseif' instead of nested ifs

### DIFF
--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -458,10 +458,20 @@ export abstract class LuaTranspiler {
         result += this.transpileStatement(node.thenStatement);
         this.popIndent();
 
-        if (node.elseStatement) {
+        let elseStatement = node.elseStatement;
+        while (elseStatement && ts.isIfStatement(elseStatement)) {
+            const elseIfCondition = this.transpileExpression(elseStatement.expression);
+            result += this.indent + `elseif ${elseIfCondition} then\n`;
+            this.pushIndent();
+            result += this.transpileStatement(elseStatement.thenStatement);
+            this.popIndent();
+            elseStatement = elseStatement.elseStatement;
+        }
+
+        if (elseStatement) {
             result += this.indent + "else\n";
             this.pushIndent();
-            result += this.transpileStatement(node.elseStatement);
+            result += this.transpileStatement(elseStatement);
             this.popIndent();
         }
 


### PR DESCRIPTION
```ts
if (foo === "a") {
    print("a");
} else if (foo === "b") {
    print("b");
} else {
    print("c")
}
```

Used to transpile to:
```lua
if foo=="a" then
    print("a");
else
    if foo=="b" then
        print("b");
    else
        print("c");
    end
end
```

And now transpiles to:
```lua
if foo=="a" then
    print("a");
elseif foo=="b" then
    print("b");
else
    print("c");
end
```

This was bothering me more than it should 😁 
