### PR TITLE
Luajit unpack fix

### DIFF
--- a/src/targets/Transpiler.JIT.ts
+++ b/src/targets/Transpiler.JIT.ts
@@ -1,5 +1,4 @@
 import { TSTLErrors } from "../Errors";
-import { LuaTranspiler } from "../Transpiler";
 import { TSHelper as tsHelper } from "../TSHelper";
 import { LuaTranspiler52 } from "./Transpiler.52";
 

--- a/src/targets/Transpiler.JIT.ts
+++ b/src/targets/Transpiler.JIT.ts
@@ -43,6 +43,6 @@ export class LuaTranspilerJIT extends LuaTranspiler52 {
 
      /** @override */
     public transpileSpreadElement(node: ts.SpreadElement): string {
-        return LuaTranspiler.prototype.transpileSpreadElement(node);
+        return "unpack(" + this.transpileExpression(node.expression) + ")";
     }
 }

--- a/src/targets/Transpiler.JIT.ts
+++ b/src/targets/Transpiler.JIT.ts
@@ -1,4 +1,5 @@
 import { TSTLErrors } from "../Errors";
+import { LuaTranspiler } from "../Transpiler";
 import { TSHelper as tsHelper } from "../TSHelper";
 import { LuaTranspiler52 } from "./Transpiler.52";
 
@@ -38,5 +39,10 @@ export class LuaTranspilerJIT extends LuaTranspiler52 {
     /** @override */
     public transpileDestructingAssignmentValue(node: ts.Expression): string {
         return `unpack(${this.transpileExpression(node)})`;
+    }
+
+     /** @override */
+    public transpileSpreadElement(node: ts.SpreadElement): string {
+        return LuaTranspiler.prototype.transpileSpreadElement(node);
     }
 }

--- a/test/unit/spreadElement.spec.ts
+++ b/test/unit/spreadElement.spec.ts
@@ -21,4 +21,20 @@ export class SpreadElementTest {
         const lua = util.transpileString(`[].push(...${JSON.stringify([1, 2, 3])});`, {luaTarget: LuaTarget.Lua51});
         Expect(lua).toBe("__TS__ArrayPush({}, unpack({1,2,3}));");
     }
+
+    @Test("Spread Element Lua 5.2")
+    public spreadElement52() {
+        const lua = util.transpileString(`[...[0, 1, 2]]`, {luaTarget: LuaTarget.Lua52, luaLibImport: "none"});
+        Expect(lua).toBe("{table.unpack({0,1,2})};");
+    }
+     @Test("Spread Element Lua 5.3")
+    public spreadElement53() {
+        const lua = util.transpileString(`[...[0, 1, 2]]`, {luaTarget: LuaTarget.Lua53, luaLibImport: "none"});
+        Expect(lua).toBe("{table.unpack({0,1,2})};");
+    }
+     @Test("Spread Element Lua JIT")
+    public spreadElementJIT() {
+        const lua = util.transpileString(`[...[0, 1, 2]]`, {luaTarget: LuaTarget.LuaJIT, luaLibImport: "none"});
+        Expect(lua).toBe("{unpack({0,1,2})};");
+    }
 }


### PR DESCRIPTION
For #258 

Fixes up transpiled spread operators

`[...[0, 1, 2]]` transpiled using the LuaJIT transpiler becomes `{unpack({0,1,2})};` instead of `{table.unpack({0,1,2})};`