### PR TITLE
Lualib omit when unused

### DIFF
--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -233,7 +233,7 @@ export abstract class LuaTranspiler {
         }
 
         // Inline lualib features
-        if (this.options.luaLibImport === LuaLibImportKind.Inline) {
+        if (this.options.luaLibImport === LuaLibImportKind.Inline && this.luaLibFeatureSet.size > 0) {
             result += "\n" + "-- Lua Library Imports\n";
             for (const feature of this.luaLibFeatureSet) {
                 const featureFile = path.resolve(__dirname, `../dist/lualib/${feature}.lua`);

--- a/test/unit/modules.spec.ts
+++ b/test/unit/modules.spec.ts
@@ -23,15 +23,6 @@ export class LuaModuleTests {
         Expect(lua.startsWith(`require("lualib_bundle")`));
     }
 
-    @Test("lualibRequireNoUses")
-    public lualibRequireNoUses(): void {
-        // Transpile
-        const lua = util.transpileString(``, { luaLibImport: LuaLibImportKind.Require, luaTarget: LuaTarget.LuaJIT });
-
-        // Assert
-        Expect(lua).toBe(``);
-    }
-
     @Test("lualibRequireAlways")
     public lualibRequireAlways(): void {
         // Transpile
@@ -62,5 +53,17 @@ export class LuaModuleTests {
         const result = util.executeLua(lua);
 
         Expect(result).toBe(3);
+    }
+
+    @TestCase(LuaLibImportKind.Inline)
+    @TestCase(LuaLibImportKind.None)
+    @TestCase(LuaLibImportKind.Require)
+    @Test("LuaLib no uses? No code")
+    public lualibNoUsesNoCode(impKind: LuaLibImportKind): void {
+        // Transpile
+        const lua = util.transpileString(``, { luaLibImport: impKind });
+
+        // Assert
+        Expect(lua).toBe(``);
     }
 }


### PR DESCRIPTION
For #240 

Stopped the `-- Lua Library Imports` header from being created for inline imports when no LuaLib features are being used.

Also added some tests to make sure no LuaLib text is generated when LuaLib is inline, required or none.