### PR TITLE
New functions

### DIFF
--- a/src/Decorator.ts
+++ b/src/Decorator.ts
@@ -21,5 +21,4 @@ export enum DecoratorKind {
     Phantom = "Phantom",
     TupleReturn = "TupleReturn",
     NoClassOr = "NoClassOr",
-    NoContext = "NoContext",
 }

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -68,4 +68,10 @@ export class TSTLErrors {
 
     public static UnsupportedObjectLiteralElement = (elementKind: ts.SyntaxKind, node: ts.Node) =>
         new TranspileError(`Unsupported object literal element: ${elementKind}.`, node)
+
+    public static UnsupportedFunctionConversion = (node: ts.Node) =>
+        new TranspileError(`Unsupported conversion from method to function.`, node)
+
+    public static UnsupportedMethodConversion = (node: ts.Node) =>
+        new TranspileError(`Unsupported conversion from function to method.`, node)
 }

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -79,11 +79,6 @@ export class TSHelper {
         return typeNode && this.isArrayTypeNode(typeNode);
     }
 
-    public static isCallableType(type: ts.Type, checker: ts.TypeChecker): boolean {
-        const sigs = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
-        return sigs.length > 0;
-    }
-
     public static isFunctionType(type: ts.Type, checker: ts.TypeChecker): boolean {
         const typeNode = checker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias);
         return typeNode && ts.isFunctionTypeNode(typeNode);
@@ -254,11 +249,6 @@ export class TSHelper {
         return [false, null, null];
     }
 
-    public static getFunctionSignature(declarations: ts.Declaration[]): ts.SignatureDeclaration {
-        return declarations
-            && declarations.find(d => (d as ts.FunctionLikeDeclaration).body !== undefined) as ts.SignatureDeclaration;
-    }
-
     public static isDeclarationWithContext(sigDecl: ts.SignatureDeclaration, checker: ts.TypeChecker): boolean {
         const thisArg = sigDecl.parameters.find(p => ts.isIdentifier(p.name)
                                                 && p.name.originalKeywordKind === ts.SyntaxKind.ThisKeyword);
@@ -285,10 +275,10 @@ export class TSHelper {
     }
 
     public static isFunctionWithContext(type: ts.Type, checker: ts.TypeChecker): boolean {
-        if (!this.isCallableType(type, checker)) {
+        const sigs = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
+        if (sigs.length === 0) {
             return false;
         }
-        const sigs = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
         const sigDecls = sigs.map(s => s.getDeclaration());
         return sigDecls.every(s => this.isDeclarationWithContext(s, checker));
     }

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -290,6 +290,6 @@ export class TSHelper {
         }
         const sigs = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
         const sigDecls = sigs.map(s => s.getDeclaration());
-        return sigDecls.some(s => this.isDeclarationWithContext(s, checker));
+        return sigDecls.every(s => this.isDeclarationWithContext(s, checker));
     }
 }

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -253,4 +253,9 @@ export class TSHelper {
         }
         return [false, null, null];
     }
+
+    public static getFunctionSignature(declarations: ts.Declaration[]): ts.SignatureDeclaration {
+        return declarations
+            && declarations.find(d => (d as ts.FunctionLikeDeclaration).body !== undefined) as ts.SignatureDeclaration;
+    }
 }

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -79,11 +79,14 @@ export class TSHelper {
         return typeNode && this.isArrayTypeNode(typeNode);
     }
 
-    public static isFunctionType(type: ts.Type, checker: ts.TypeChecker): boolean {
+    public static isCallableType(type: ts.Type, checker: ts.TypeChecker): boolean {
         const sigs = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
         return sigs.length > 0;
-        // const typeNode = checker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias);
-        // return typeNode && ts.isFunctionTypeNode(typeNode);
+    }
+
+    public static isFunctionType(type: ts.Type, checker: ts.TypeChecker): boolean {
+        const typeNode = checker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias);
+        return typeNode && ts.isFunctionTypeNode(typeNode);
     }
 
     public static isTupleReturnCall(node: ts.Node, checker: ts.TypeChecker): boolean {

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -80,8 +80,10 @@ export class TSHelper {
     }
 
     public static isFunctionType(type: ts.Type, checker: ts.TypeChecker): boolean {
-        const typeNode = checker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias);
-        return typeNode && ts.isFunctionTypeNode(typeNode);
+        const sigs = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
+        return sigs.length > 0;
+        // const typeNode = checker.typeToTypeNode(type, undefined, ts.NodeBuilderFlags.InTypeAlias);
+        // return typeNode && ts.isFunctionTypeNode(typeNode);
     }
 
     public static isTupleReturnCall(node: ts.Node, checker: ts.TypeChecker): boolean {

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1421,12 +1421,11 @@ export abstract class LuaTranspiler {
 
     public validateAssignment(fromType: ts.Type, toType: ts.Type, pos: number): void {
         if ((fromType as ts.TypeReference).typeArguments && (toType as ts.TypeReference).typeArguments) {
+            // Recurse into tuples/arrays
             (fromType as ts.TypeReference).typeArguments.forEach((t, i) => {
-                // Recurse into tuples
                 this.validateAssignment(t, (toType as ts.TypeReference).typeArguments[i], pos);
             });
-
-        } else if (tsHelper.isCallableType(toType, this.checker) && tsHelper.isCallableType(fromType, this.checker)) {
+        } else {
             // Check function assignments
             const fromHasContext = tsHelper.isFunctionWithContext(fromType, this.checker);
             const toHasContext = tsHelper.isFunctionWithContext(toType, this.checker);

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -92,8 +92,9 @@ export abstract class LuaTranspiler {
         this.importCount = 0;
         this.sourceFile = sourceFile;
         this.isModule = tsHelper.isFileModule(sourceFile);
-        this.isStrict = options.alwaysStrict || options.strict
-            || (options.target && options.target > ts.ScriptTarget.ES5);
+        this.isStrict = options.alwaysStrict
+            || (options.strict && options.alwaysStrict !== false)
+            || (this.isModule && options.target && options.target >= ts.ScriptTarget.ES2015);
         this.loopStack = [];
         this.classStack = [];
         this.exportStack = [];

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1398,6 +1398,12 @@ export abstract class LuaTranspiler {
 
     public transpileFunctionCallExpression(node: ts.CallExpression): string {
         const expression = node.expression as ts.PropertyAccessExpression;
+        const callerType = this.checker.getTypeAtLocation(expression.expression);
+        if (!tsHelper.isFunctionWithContext(callerType, this.checker)) {
+            const linePos = ts.getLineAndCharacterOfPosition(this.sourceFile, node.pos);
+            console.error(`${this.sourceFile.fileName}:${linePos.line + 1}:${linePos.character} `
+                          + `Cannot convert function to method`);
+        }
         const params = this.transpileArguments(node.arguments);
         const caller = this.transpileExpression(expression.expression);
         const expressionName = this.transpileIdentifier(expression.name);

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1162,7 +1162,8 @@ export abstract class LuaTranspiler {
             if (!ts.isPropertyAccessExpression(node.expression)
                 && !ts.isElementAccessExpression(node.expression)
                 && !tsHelper.getCustomDecorators(type, this.checker).has(DecoratorKind.NoContext)) {
-                params = this.transpileArguments(node.arguments, ts.createIdentifier(this.isStrict ? "nil" : "_G"));
+                const context = this.isStrict ? ts.createNull() :  ts.createIdentifier("_G");
+                params = this.transpileArguments(node.arguments, context);
             } else {
                 params = this.transpileArguments(node.arguments);
             }
@@ -1201,7 +1202,8 @@ export abstract class LuaTranspiler {
         if (!ts.isPropertyAccessExpression(node.expression)
             && !ts.isElementAccessExpression(node.expression)
             && !tsHelper.getCustomDecorators(type, this.checker).has(DecoratorKind.NoContext)) {
-            params = this.transpileArguments(node.arguments, ts.createIdentifier(this.isStrict ? "nil" : "_G"));
+            const context = this.isStrict ? ts.createNull() :  ts.createIdentifier("_G");
+            params = this.transpileArguments(node.arguments, context);
         } else {
             params = this.transpileArguments(node.arguments);
         }
@@ -1405,12 +1407,7 @@ export abstract class LuaTranspiler {
 
         // Add context as first param if present
         if (context) {
-            if (ts.isIdentifier(context) && context.text === "nil") {
-                // Avoid "Error: Cannot use Lua keyword nil as identifier."
-                parameters.push("nil");
-            } else {
-                parameters.push(this.transpileExpression(context));
-            }
+            parameters.push(this.transpileExpression(context));
         }
 
         params.forEach(param => {

--- a/src/lualib/ArrayConcat.ts
+++ b/src/lualib/ArrayConcat.ts
@@ -1,9 +1,6 @@
-/** !NoContext */
 declare function pcall(func: () => any): any;
-/** !NoContext */
 declare function type(val: any): string;
 
-/** !NoContext */
 function __TS__ArrayConcat(arr1: any[], ...args: any[]): any[] {
   const out: any[] = [];
   for (const val of arr1) {

--- a/src/lualib/ArrayEvery.ts
+++ b/src/lualib/ArrayEvery.ts
@@ -1,4 +1,3 @@
-/** !NoContext */
 function __TS__ArrayEvery<T>(arr: T[], callbackfn: (value: T, index?: number, array?: any[]) => boolean): boolean {
     for (let i = 0; i < arr.length; i++) {
         if (!callbackfn(arr[i], i, arr)) {

--- a/src/lualib/ArrayFilter.ts
+++ b/src/lualib/ArrayFilter.ts
@@ -1,4 +1,3 @@
-/** !NoContext */
 function __TS__ArrayFilter<T>(arr: T[], callbackfn: (value: T, index?: number, array?: any[]) => boolean): T[] {
     const result: T[] = [];
     for (let i = 0; i < arr.length; i++) {

--- a/src/lualib/ArrayForEach.ts
+++ b/src/lualib/ArrayForEach.ts
@@ -1,4 +1,3 @@
-/** !NoContext */
 function __TS__ArrayForEach<T>(arr: T[], callbackFn: (value: T, index?: number, array?: any[]) => any): void {
     for (let i = 0; i < arr.length; i++) {
         callbackFn(arr[i], i, arr);

--- a/src/lualib/ArrayIndexOf.ts
+++ b/src/lualib/ArrayIndexOf.ts
@@ -1,4 +1,3 @@
-/** !NoContext */
 function __TS__ArrayIndexOf<T>(arr: T[], searchElement: T, fromIndex?: number): number {
     const len = arr.length;
     if (len === 0) {

--- a/src/lualib/ArrayMap.ts
+++ b/src/lualib/ArrayMap.ts
@@ -1,4 +1,3 @@
-/** !NoContext */
 function __TS__ArrayMap<T, U>(arr: T[], callbackfn: (value: T, index?: number, array?: T[]) => U): U[] {
     const newArray: U[] = [];
     for (let i = 0; i < arr.length; i++) {

--- a/src/lualib/ArrayPush.ts
+++ b/src/lualib/ArrayPush.ts
@@ -1,4 +1,3 @@
-/** !NoContext */
 function __TS__ArrayPush<T>(arr: T[], ...items: T[]): number {
     for (const item of items) {
         arr[arr.length] = item;

--- a/src/lualib/ArrayReverse.ts
+++ b/src/lualib/ArrayReverse.ts
@@ -1,4 +1,3 @@
-/** !NoContext */
 function __TS__ArrayReverse(arr: any[]): any[] {
     let i = 0;
     let j = arr.length - 1;

--- a/src/lualib/ArrayShift.ts
+++ b/src/lualib/ArrayShift.ts
@@ -1,8 +1,6 @@
 declare namespace table {
-    /** !NoContext */
     function remove<T>(arr: T[], idx: number): T;
 }
-/** !NoContext */
 function __TS__ArrayShift<T>(arr: T[]): T {
     return table.remove(arr, 1);
 }

--- a/src/lualib/ArraySlice.ts
+++ b/src/lualib/ArraySlice.ts
@@ -1,5 +1,4 @@
 // https://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf 22.1.3.23
-/** !NoContext */
 function __TS__ArraySlice<T>(list: T[], first: number, last: number): T[] {
     const len = list.length;
 

--- a/src/lualib/ArraySome.ts
+++ b/src/lualib/ArraySome.ts
@@ -1,4 +1,3 @@
-/** !NoContext */
 function __TS__ArraySome<T>(arr: T[], callbackfn: (value: T, index?: number, array?: any[]) => boolean): boolean {
     for (let i = 0; i < arr.length; i++) {
         if (callbackfn(arr[i], i, arr)) {

--- a/src/lualib/ArraySort.ts
+++ b/src/lualib/ArraySort.ts
@@ -1,8 +1,6 @@
 declare namespace table {
-    /** !NoContext */
     function sort<T>(arr: T[], compareFn?: (a: T, b: T) => number): void;
 }
-/** !NoContext */
 function __TS__ArraySort<T>(arr: T[], compareFn?: (a: T, b: T) => number): T[] {
     table.sort(arr, compareFn);
     return arr;

--- a/src/lualib/ArraySplice.ts
+++ b/src/lualib/ArraySplice.ts
@@ -1,4 +1,3 @@
-/** !NoContext */
 function __TS__ArraySplice<T>(list: T[], start: number, deleteCount: number, ...items: T[]): T[] {
 
     const len = list.length;

--- a/src/lualib/ArrayUnshift.ts
+++ b/src/lualib/ArrayUnshift.ts
@@ -1,8 +1,6 @@
 declare namespace table {
-    /** !NoContext */
     function insert<T>(arr: T[], idx: number, val: T): void;
 }
-/** !NoContext */
 function __TS__ArrayUnshift<T>(arr: T[],  ...items: T[]): number {
     for (let i = items.length - 1; i >= 0; --i) {
         table.insert(arr, 1, items[i]);

--- a/src/lualib/FunctionApply.ts
+++ b/src/lualib/FunctionApply.ts
@@ -1,15 +1,11 @@
-/** !NoContext */
 declare function unpack<T>(list: T[], i?: number, j?: number): T[];
 
 declare namespace table {
-    /** !NoContext */
     export function unpack<T>(list: T[], i?: number, j?: number): T[];
 }
 
-/** !NoContext */
 type ApplyFn = (...argArray: any[]) => any;
 
-/** !NoContext */
 function __TS__FunctionApply(fn: ApplyFn, thisArg: any, argsArray?: any[]): any {
     if (argsArray) {
         return fn(thisArg, (unpack || table.unpack)(argsArray));

--- a/src/lualib/FunctionBind.ts
+++ b/src/lualib/FunctionBind.ts
@@ -1,18 +1,13 @@
-/** !NoContext */
 declare function unpack<T>(list: T[], i?: number, j?: number): T[];
 
 declare namespace table {
-    /** !NoContext */
     export function insert<T>(t: T[], pos: number, value: T): void;
 
-    /** !NoContext */
     export function unpack<T>(list: T[], i?: number, j?: number): T[];
 }
 
-/** !NoContext */
 type BindFn = (...argArray: any[]) => any;
 
-/** !NoContext */
 function __TS__FunctionBind(fn: BindFn, thisArg: any, ...boundArgs: any[]): (...args: any[]) => any {
     return (...argArray: any[]) => {
         for (let i = 0; i < boundArgs.length; ++i) {

--- a/src/lualib/FunctionCall.ts
+++ b/src/lualib/FunctionCall.ts
@@ -1,15 +1,11 @@
-/** !NoContext */
 declare function unpack<T>(list: T[], i?: number, j?: number): T[];
 
 declare namespace table {
-    /** !NoContext */
     export function unpack<T>(list: T[], i?: number, j?: number): T[];
 }
 
-/** !NoContext */
 type CallFn = (...argArray: any[]) => any;
 
-/** !NoContext */
 function __TS__FunctionCall(fn: CallFn, thisArg: any, ...args: any[]): any {
     return fn(thisArg, (unpack || table.unpack)(args));
 }

--- a/src/lualib/InstanceOf.ts
+++ b/src/lualib/InstanceOf.ts
@@ -3,7 +3,6 @@ interface LuaClass {
     __base: LuaClass;
 }
 
-/** !NoContext */
 function __TS__InstanceOf(obj: LuaClass, classTbl: LuaClass): boolean {
     while (obj !== undefined) {
         if (obj.__index === classTbl) {

--- a/src/lualib/StringReplace.ts
+++ b/src/lualib/StringReplace.ts
@@ -1,10 +1,8 @@
 declare namespace string {
-    /** !NoContext */
     /** !TupleReturn */
     function gsub(source: string, searchValue: string, replaceValue: string): [string, number];
 }
 
-/** !NoContext */
 function __TS__StringReplace(source: string, searchValue: string, replaceValue: string): string {
     return string.gsub(source, searchValue, replaceValue)[0];
 }

--- a/src/lualib/StringSplit.ts
+++ b/src/lualib/StringSplit.ts
@@ -1,4 +1,3 @@
-/** !NoContext */
 function __TS__StringSplit(source: string, separator?: string, limit?: number): string[] {
     if (limit === undefined) {
         limit = 4294967295;

--- a/src/lualib/Ternary.ts
+++ b/src/lualib/Ternary.ts
@@ -1,4 +1,3 @@
-/** !NoContext */
 function __TS__Ternary<T>(condition: boolean, cb1: () => T, cb2: () => T): T {
     if (condition) {
         return cb1();

--- a/test/src/util.ts
+++ b/test/src/util.ts
@@ -3,7 +3,8 @@ import * as ts from "typescript";
 
 import { Expect } from "alsatian";
 
-import { transpileString } from "../../src/Compiler";
+import { transpileString as _transpileString } from "../../src/Compiler";
+import { CompilerOptions } from "../../src/CompilerOptions";
 import { LuaTarget, LuaTranspiler } from "../../src/Transpiler";
 import { createTranspiler } from "../../src/TranspilerFactory";
 
@@ -11,7 +12,9 @@ import {lauxlib, lua, lualib, to_jsstring, to_luastring } from "fengari";
 
 import * as fs from "fs";
 
-export { transpileString };
+export function transpileString(str: string, options?: CompilerOptions): string {
+    return _transpileString("/** !NoContext */ declare function JSONStringify(t: any): string;\n" + str, options);
+}
 
 export function executeLua(luaStr: string, withLib = true): any {
     if (withLib) {

--- a/test/src/util.ts
+++ b/test/src/util.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 
 import { Expect } from "alsatian";
 
-import { transpileString as _transpileString } from "../../src/Compiler";
+import { transpileString } from "../../src/Compiler";
 import { CompilerOptions } from "../../src/CompilerOptions";
 import { LuaTarget, LuaTranspiler } from "../../src/Transpiler";
 import { createTranspiler } from "../../src/TranspilerFactory";
@@ -12,9 +12,7 @@ import {lauxlib, lua, lualib, to_jsstring, to_luastring } from "fengari";
 
 import * as fs from "fs";
 
-export function transpileString(str: string, options?: CompilerOptions): string {
-    return _transpileString("/** !NoContext */ declare function JSONStringify(t: any): string;\n" + str, options);
-}
+export { transpileString };
 
 export function executeLua(luaStr: string, withLib = true): any {
     if (withLib) {

--- a/test/translation/lua/callNamespace.lua
+++ b/test/translation/lua/callNamespace.lua
@@ -1,1 +1,1 @@
-Namespace:myFunction();
+Namespace.myFunction();

--- a/test/translation/lua/dotColonFunctionCalls.lua
+++ b/test/translation/lua/dotColonFunctionCalls.lua
@@ -2,5 +2,5 @@ classInstance:colonMethod();
 classInstance:dotMethod();
 interfaceInstance:colonMethod();
 interfaceInstance:dotMethod();
-TestNameSpace:dotMethod();
-TestNameSpace:dotMethod2();
+TestNameSpace.dotMethod();
+TestNameSpace.dotMethod2();

--- a/test/translation/lua/functionRestArguments.lua
+++ b/test/translation/lua/functionRestArguments.lua
@@ -1,3 +1,3 @@
-function varargsFunction(self,a,...)
+function varargsFunction(a,...)
     local b = { ... }
 end

--- a/test/translation/lua/modulesFunctionExport.lua
+++ b/test/translation/lua/modulesFunctionExport.lua
@@ -1,5 +1,5 @@
 local exports = exports or {}
-local function publicFunc(self)
+local function publicFunc()
 end
 exports.publicFunc = publicFunc
 return exports

--- a/test/translation/lua/modulesFunctionNoExport.lua
+++ b/test/translation/lua/modulesFunctionNoExport.lua
@@ -1,2 +1,2 @@
-function publicFunc(self)
+function publicFunc()
 end

--- a/test/translation/lua/modulesNamespaceNestedWithMemberExport.lua
+++ b/test/translation/lua/modulesNamespaceNestedWithMemberExport.lua
@@ -3,7 +3,7 @@ local TestSpace = exports.TestSpace or TestSpace or {}
 do
     local TestNestedSpace = TestNestedSpace or {}
     do
-        local function innerFunc(self)
+        local function innerFunc()
         end
         TestNestedSpace.innerFunc = innerFunc
     end

--- a/test/translation/lua/modulesNamespaceWithMemberExport.lua
+++ b/test/translation/lua/modulesNamespaceWithMemberExport.lua
@@ -1,7 +1,7 @@
 local exports = exports or {}
 local TestSpace = exports.TestSpace or TestSpace or {}
 do
-    local function innerFunc(self)
+    local function innerFunc()
     end
     TestSpace.innerFunc = innerFunc
 end

--- a/test/translation/lua/modulesNamespaceWithMemberNoExport.lua
+++ b/test/translation/lua/modulesNamespaceWithMemberNoExport.lua
@@ -1,7 +1,7 @@
 local exports = exports or {}
 local TestSpace = exports.TestSpace or TestSpace or {}
 do
-    local function innerFunc(self)
+    local function innerFunc()
     end
 end
 exports.TestSpace = TestSpace

--- a/test/translation/lua/namespace.lua
+++ b/test/translation/lua/namespace.lua
@@ -1,5 +1,5 @@
 myNamespace = myNamespace or {}
 do
-    local function nsMember(self)
+    local function nsMember()
     end
 end

--- a/test/translation/lua/namespaceMerge.lua
+++ b/test/translation/lua/namespaceMerge.lua
@@ -9,10 +9,10 @@ end
 end
 function MergedClass.constructor(self)
 end
-function MergedClass.staticMethodA(self)
+function MergedClass.staticMethodA()
 end
-function MergedClass.staticMethodB(self)
-    self:staticMethodA();
+function MergedClass.staticMethodB()
+    self.staticMethodA();
 end
 function MergedClass.methodA(self)
 end
@@ -22,12 +22,12 @@ function MergedClass.methodB(self)
 end
 MergedClass = MergedClass or {}
 do
-    local function namespaceFunc(self)
+    local function namespaceFunc()
     end
     MergedClass.namespaceFunc = namespaceFunc
 end
 local mergedClass = MergedClass.new(true);
 mergedClass:methodB();
 mergedClass:propertyFunc();
-MergedClass:staticMethodB();
-MergedClass:namespaceFunc();
+MergedClass.staticMethodB();
+MergedClass.namespaceFunc();

--- a/test/translation/lua/namespaceNested.lua
+++ b/test/translation/lua/namespaceNested.lua
@@ -2,7 +2,7 @@ myNamespace = myNamespace or {}
 do
     local myNestedNamespace = myNestedNamespace or {}
     do
-        local function nsMember(self)
+        local function nsMember()
         end
     end
 end

--- a/test/translation/lua/namespacePhantom.lua
+++ b/test/translation/lua/namespacePhantom.lua
@@ -1,2 +1,2 @@
-function nsMember(self)
+function nsMember()
 end

--- a/test/translation/lua/returnDefault.lua
+++ b/test/translation/lua/returnDefault.lua
@@ -1,3 +1,3 @@
-function myFunc(self)
+function myFunc()
     return
 end

--- a/test/translation/lua/shorthandPropertyAssignment.lua
+++ b/test/translation/lua/shorthandPropertyAssignment.lua
@@ -1,3 +1,3 @@
-local f; f = function(_,x)
+local f; f = function(x)
     return ({x = x})
 end;

--- a/test/translation/lua/tupleReturn.lua
+++ b/test/translation/lua/tupleReturn.lua
@@ -1,28 +1,28 @@
-function tupleReturn(self)
+function tupleReturn()
     return 0,"foobar"
 end
-tupleReturn(_G);
-noTupleReturn(_G);
-local a,b=tupleReturn(_G);
-local c,d=table.unpack(noTupleReturn(_G));
-do local __TS_tmp0,__TS_tmp1 = tupleReturn(_G); a,b = __TS_tmp0,__TS_tmp1 end;
-do local __TS_tmp0,__TS_tmp1 = table.unpack(noTupleReturn(_G)); c,d = __TS_tmp0,__TS_tmp1 end;
-local e = ({ tupleReturn(_G) });
-local f = noTupleReturn(_G);
-e = ({ tupleReturn(_G) });
-f = noTupleReturn(_G);
-foo(_G,({ tupleReturn(_G) }));
-foo(_G,noTupleReturn(_G));
-function tupleReturnFromVar(self)
+tupleReturn();
+noTupleReturn();
+local a,b=tupleReturn();
+local c,d=table.unpack(noTupleReturn());
+do local __TS_tmp0,__TS_tmp1 = tupleReturn(); a,b = __TS_tmp0,__TS_tmp1 end;
+do local __TS_tmp0,__TS_tmp1 = table.unpack(noTupleReturn()); c,d = __TS_tmp0,__TS_tmp1 end;
+local e = ({ tupleReturn() });
+local f = noTupleReturn();
+e = ({ tupleReturn() });
+f = noTupleReturn();
+foo(({ tupleReturn() }));
+foo(noTupleReturn());
+function tupleReturnFromVar()
     local r = {1,"baz"};
     return table.unpack(r)
 end
-function tupleReturnForward(self)
-    return tupleReturn(_G)
+function tupleReturnForward()
+    return tupleReturn()
 end
-function tupleNoForward(self)
-    return ({ tupleReturn(_G) })
+function tupleNoForward()
+    return ({ tupleReturn() })
 end
-function tupleReturnUnpack(self)
-    return table.unpack(tupleNoForward(_G))
+function tupleReturnUnpack()
+    return table.unpack(tupleNoForward())
 end

--- a/test/translation/ts/assignments.ts
+++ b/test/translation/ts/assignments.ts
@@ -2,19 +2,14 @@ declare let x: number;
 declare let y: number;
 declare let z: number;
 declare let obj: {prop: number, arr: number[]};
-/** !NoContext */
 declare function getObj(): typeof obj;
 declare let arr: number[];
 declare let arr2: number[][];
-/** !NoContext */
 declare function getArr(): typeof arr;
-/** !NoContext */
 declare function getIndex(): number;
 declare let xTup: [number, number];
 declare let yTup: [number, number];
-/** !NoContext */
 declare function getTup(): [number, number];
-/** !NoContext */
 /** !TupleReturn */
 declare function getTupRet(): [number, number];
 x = y;

--- a/test/unit/assignmentDestructuring.spec.ts
+++ b/test/unit/assignmentDestructuring.spec.ts
@@ -15,7 +15,7 @@ export class AssignmentDestructuringTests {
             this.assignmentDestruturingTs, {luaTarget: LuaTarget.Lua51, luaLibImport: "none"}
         );
         // Assert
-        Expect(lua).toBe(`local a,b=unpack(myFunc(_G));`);
+        Expect(lua).toBe(`local a,b=unpack(myFunc());`);
     }
 
     @Test("Assignment destructuring [5.2]")
@@ -25,6 +25,6 @@ export class AssignmentDestructuringTests {
             this.assignmentDestruturingTs, {luaTarget: LuaTarget.Lua52, luaLibImport: "none"}
         );
         // Assert
-        Expect(lua).toBe(`local a,b=table.unpack(myFunc(_G));`);
+        Expect(lua).toBe(`local a,b=table.unpack(myFunc());`);
     }
 }

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -81,7 +81,7 @@ export class AssignmentTests {
                    + `let [a,b] = abc();`;
 
         const lua = util.transpileString(code);
-        Expect(lua).toBe("local a,b=abc(_G);");
+        Expect(lua).toBe("local a,b=abc();");
     }
 
     @Test("TupleReturn Single assignment")
@@ -92,7 +92,7 @@ export class AssignmentTests {
                    + `a = abc();`;
 
         const lua = util.transpileString(code);
-        Expect(lua).toBe("local a = ({ abc(_G) });\na = ({ abc(_G) });");
+        Expect(lua).toBe("local a = ({ abc() });\na = ({ abc() });");
     }
 
     @Test("TupleReturn interface assignment")
@@ -116,7 +116,7 @@ export class AssignmentTests {
                    + `let [a,b] = def.abc();`;
 
         const lua = util.transpileString(code);
-        Expect(lua).toBe("local a,b=def:abc();");
+        Expect(lua).toBe("local a,b=def.abc();");
     }
 
     @Test("TupleReturn method assignment")

--- a/test/unit/curry.spec.ts
+++ b/test/unit/curry.spec.ts
@@ -10,8 +10,8 @@ export class LuaCurryTests {
             `(x: number) => (y: number) => x + y;`
         );
         // Assert
-        Expect(lua).toBe(`function(_,x)
-    return function(_,y)
+        Expect(lua).toBe(`function(x)
+    return function(y)
         return x+y
     end
 end;`);

--- a/test/unit/functions.spec.ts
+++ b/test/unit/functions.spec.ts
@@ -233,7 +233,7 @@ export class FunctionTests {
 
     @Test("Function bind")
     public functionBind(): void {
-        const source = `const abc = function (a: string, b: string) { return this.a + a + b; }
+        const source = `const abc = function (this: { a: number }, a: string, b: string) { return this.a + a + b; }
                         return abc.bind({ a: 4 }, "b")("c");`;
 
         const result = util.transpileAndExecute(source);
@@ -243,7 +243,7 @@ export class FunctionTests {
 
     @Test("Function apply")
     public functionApply(): void {
-        const source = `const abc = function (a: string) { return this.a + a; }
+        const source = `const abc = function (this: { a: number }, a: string) { return this.a + a; }
                         return abc.apply({ a: 4 }, ["b"]);`;
 
         const result = util.transpileAndExecute(source);
@@ -253,7 +253,7 @@ export class FunctionTests {
 
     @Test("Function call")
     public functionCall(): void {
-        const source = `const abc = function (a: string) { return this.a + a; }
+        const source = `const abc = function (this: { a: number }, a: string) { return this.a + a; }
                         return abc.call({ a: 4 }, "b");`;
 
         const result = util.transpileAndExecute(source);

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -18,7 +18,6 @@ export class LuaLoopTests {
                 arrTest[i] = arrTest[i] + 1;
                 i++;
             }
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(arrTest);`
         );
 
@@ -53,7 +52,6 @@ export class LuaLoopTests {
 
                 i++;
             }
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(arrTest);`
         );
 
@@ -88,7 +86,6 @@ export class LuaLoopTests {
 
                 i++;
             } while (i < arrTest.length)
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(arrTest);`
         );
 
@@ -108,7 +105,6 @@ export class LuaLoopTests {
             for (let i = 0; i < arrTest.length; ++i) {
                 arrTest[i] = arrTest[i] + 1;
             }
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(arrTest);`
         );
 
@@ -137,7 +133,6 @@ export class LuaLoopTests {
                     arrTest[i] = j;
                 }
             }
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(arrTest);
             `
         );
@@ -158,7 +153,6 @@ export class LuaLoopTests {
             for (let i = 0; arrTest.length > i; i++) {
                 arrTest[i] = arrTest[i] + 1;
             }
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(arrTest);`
         );
 
@@ -179,7 +173,6 @@ export class LuaLoopTests {
                 break;
                 arrTest[i] = arrTest[i] + 1;
             }
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(arrTest);`
         );
 
@@ -206,7 +199,6 @@ export class LuaLoopTests {
             for (${header}) {
                 arrTest[i] = arrTest[i] + 1;
             }
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(arrTest);`
         );
 
@@ -226,7 +218,6 @@ export class LuaLoopTests {
             for (let key in objTest) {
                 objTest[key] = objTest[key] + 1;
             }
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(objTest);`
         );
 
@@ -264,7 +255,6 @@ export class LuaLoopTests {
 
                 obj[i] = 0;
             }
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(obj);
             `
         );
@@ -286,7 +276,6 @@ export class LuaLoopTests {
             for (let value of objTest) {
                 arrResultTest.push(value + 1)
             }
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(arrResultTest);`
         );
 
@@ -318,7 +307,6 @@ export class LuaLoopTests {
                 }
                 a++;
             }
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(testArr);`
         );
 

--- a/test/unit/lualib/lualib.spec.ts
+++ b/test/unit/lualib/lualib.spec.ts
@@ -12,7 +12,6 @@ export class LuaLibArrayTests {
             arrTest.forEach((elem, index) => {
                 arrTest[index] = arrTest[index] + 1;
             })
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(arrTest);`
         );
 
@@ -32,8 +31,7 @@ export class LuaLibArrayTests {
     @Test("array.map")
     public map<T>(inp: T[], func: string) {
         // Transpile
-        const lua = util.transpileString(`/** !NoContext */ declare function JSONStringify(t: any): string;
-            return JSONStringify([${inp.toString()}].map(${func}))`);
+        const lua = util.transpileString(`return JSONStringify([${inp.toString()}].map(${func}))`);
 
         // Execute
         const result = util.executeLua(lua);
@@ -52,8 +50,7 @@ export class LuaLibArrayTests {
     @Test("array.filter")
     public filter<T>(inp: T[], func: string) {
         // Transpile
-        const lua = util.transpileString(`/** !NoContext */ declare function JSONStringify(t: any): string;
-            return JSONStringify([${inp.toString()}].filter(${func}))`);
+        const lua = util.transpileString(`return JSONStringify([${inp.toString()}].filter(${func}))`);
 
         // Execute
         const result = util.executeLua(lua);
@@ -69,8 +66,7 @@ export class LuaLibArrayTests {
     @Test("array.every")
     public every<T>(inp: T[], func: string) {
         // Transpile
-        const lua = util.transpileString(`/** !NoContext */ declare function JSONStringify(t: any): string;
-            return JSONStringify([${inp.toString()}].every(${func})))`);
+        const lua = util.transpileString(`return JSONStringify([${inp.toString()}].every(${func})))`);
 
         // Execute
         const result = util.executeLua(lua);
@@ -86,8 +82,7 @@ export class LuaLibArrayTests {
     @Test("array.some")
     public some<T>(inp: T[], func: string) {
         // Transpile
-        const lua = util.transpileString(`/** !NoContext */ declare function JSONStringify(t: any): string;
-            return JSONStringify([${inp.toString()}].some(${func})))`);
+        const lua = util.transpileString(`return JSONStringify([${inp.toString()}].some(${func})))`);
 
         // Execute
         const result = util.executeLua(lua);
@@ -106,8 +101,7 @@ export class LuaLibArrayTests {
     @Test("array.slice")
     public slice<T>(inp: T[], start: number, end?: number) {
         // Transpile
-        const lua = util.transpileString(`/** !NoContext */ declare function JSONStringify(t: any): string;
-            return JSONStringify([${inp.toString()}].slice(${start}, ${end}))`);
+        const lua = util.transpileString(`return JSONStringify([${inp.toString()}].slice(${start}, ${end}))`);
 
         // Execute
         const result = util.executeLua(lua);
@@ -129,7 +123,6 @@ export class LuaLibArrayTests {
         const lua = util.transpileString(
             `let spliceTestTable = [${inp.toString()}];
             spliceTestTable.splice(${start}, ${deleteCount}, ${newElements});
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(spliceTestTable);`
         );
 
@@ -156,14 +149,12 @@ export class LuaLibArrayTests {
             lua = util.transpileString(
                `let spliceTestTable = [${inp.toString()}];
                spliceTestTable.splice(${start}, ${deleteCount}, ${newElements});
-               /** !NoContext */ declare function JSONStringify(t: any): string;
                return JSONStringify(spliceTestTable);`
             );
         } else {
             lua = util.transpileString(
                `let spliceTestTable = [${inp.toString()}];
                spliceTestTable.splice(${start});
-               /** !NoContext */ declare function JSONStringify(t: any): string;
                return JSONStringify(spliceTestTable);`
             );
         }
@@ -197,7 +188,6 @@ export class LuaLibArrayTests {
         // Transpile
         const lua = util.transpileString(
             `let concatTestTable = ${JSON.stringify(arr)};
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(concatTestTable.concat(${argStr}));`
         );
 
@@ -288,7 +278,6 @@ export class LuaLibArrayTests {
         const lua = util.transpileString(
             `let testArray = [0];
             testArray.push(${inp.join(", ")});
-            /** !NoContext */ declare function JSONStringify(t: any): string;
             return JSONStringify(testArray);
             `
             );
@@ -343,7 +332,6 @@ export class LuaLibArrayTests {
             const lua = util.transpileString(
                 `let testArray = ${array};
                 let val = testArray.reverse();
-                /** !NoContext */ declare function JSONStringify(t: any): string;
                 return JSONStringify(testArray)`);
 
             // Execute
@@ -364,7 +352,6 @@ export class LuaLibArrayTests {
                 const lua = util.transpileString(
                     `let testArray = ${array};
                     let val = testArray.shift();
-                    /** !NoContext */ declare function JSONStringify(t: any): string;
                     return JSONStringify(testArray)`);
 
                 // Execute
@@ -398,7 +385,6 @@ export class LuaLibArrayTests {
             const lua = util.transpileString(
                 `let testArray = ${array};
                 testArray.unshift(${toUnshift});
-                /** !NoContext */ declare function JSONStringify(t: any): string;
                 return JSONStringify(testArray)`);
             // Execute
             const result = util.executeLua(lua);
@@ -418,7 +404,6 @@ export class LuaLibArrayTests {
             const lua = util.transpileString(
                 `let testArray = ${array};
                 testArray.sort();
-                /** !NoContext */ declare function JSONStringify(t: any): string;
                 return JSONStringify(testArray)`);
 
             // Execute

--- a/test/unit/objectLiteral.spec.ts
+++ b/test/unit/objectLiteral.spec.ts
@@ -9,7 +9,7 @@ export class ObjectLiteralTests {
     @TestCase(`{"a":3,b:"4"}`, `{["a"] = 3,b = "4"};`)
     @TestCase(`{["a"]:3,b:"4"}`, `{["a"] = 3,b = "4"};`)
     @TestCase(`{["a"+123]:3,b:"4"}`, `{["a" .. 123] = 3,b = "4"};`)
-    @TestCase(`{[myFunc()]:3,b:"4"}`, `{[myFunc(_G)] = 3,b = "4"};`)
+    @TestCase(`{[myFunc()]:3,b:"4"}`, `{[myFunc()] = 3,b = "4"};`)
     @TestCase(`{x}`, `{x = x};`)
     @Test("Object Literal")
     public objectLiteral(inp: string, out: string) {

--- a/test/unit/spreadElement.spec.ts
+++ b/test/unit/spreadElement.spec.ts
@@ -10,8 +10,7 @@ export class SpreadElementTest {
     @TestCase([1, "test", 3])
     @Test("Spread Element Push")
     public spreadElementPush(inp: any[]) {
-        const lua = util.transpileString(`/** !NoContext */ declare function JSONStringify(t: any): string;
-            return JSONStringify([].push(...${JSON.stringify(inp)}));`);
+        const lua = util.transpileString(`return JSONStringify([].push(...${JSON.stringify(inp)}));`);
         const result = util.executeLua(lua);
         Expect(result).toBe([].push(...inp));
     }

--- a/test/unit/string.spec.ts
+++ b/test/unit/string.spec.ts
@@ -274,8 +274,7 @@ export class StringTests {
     public split(inp: string, separator: string): void {
         // Transpile
         const lua = util.transpileString(
-            `/** !NoContext */ declare function JSONStringify(t: any): string;
-            return JSONStringify("${inp}".split("${separator}"))`
+            `return JSONStringify("${inp}".split("${separator}"))`
         );
 
         // Execute


### PR DESCRIPTION
This PR brings everything up to what is spec'd out here: https://github.com/Perryvw/TypescriptToLua/issues/250#issuecomment-437894204
- non-static class/interface methods and function properties (lambdas) are given a context parameter
- static methods/lambdas and stand-alone functions have no context parameter
- errors are thrown for attempts to assign methods to non-methods and vice-versa
- stand-alone functions can be given a context by explicitly adding a 'this' parameter
- methods can be declared without a context by explicitly declaring a 'this: void' parameter

A few notes:
- NoContext decorator has been removed
- bind/call/apply currently throw errors when called with non-methods. Are there any good reasons to support this?
- Custom constructor functions are expected to be non-methods. If that needs to be supported, it might need to be an option in the decorator.

Current edge cases:
```ts
interface Func<T> {
    (this: T, s: string): string;
}
let fn: Func<void> = foo.method; // Should Error
```
Right now, Func<void> is detected as having context when it shouldn't. I need to figure out how to resolve the generic parameter when checking assignments.

```ts
interface A {
    method(s: string): string;
}
interface B {
    method(this: void, s: string): string;
}
declare let a: A;
let b: B = a; // Should Error
```
Assigning to interfaces allows the check to be bypassed and calling the method on 'b' will incorrectly use the dot syntax. This should be solvable by recursively checking assignments to interface types, but this is complex and will likely add quite a lot of overhead. Need to think on this one...
