### PR TITLE
Feature/jsdoc annotations

### DIFF
--- a/src/Decorator.ts
+++ b/src/Decorator.ts
@@ -1,14 +1,30 @@
 export class Decorator {
+
+    public static isValid(decoratorKindString: string): boolean {
+        return this.getDecoratorKind(decoratorKindString) !== undefined;
+    }
+
+    public static getDecoratorKind(decoratorKindString: string): DecoratorKind {
+        switch (decoratorKindString.toLowerCase()) {
+            case "extension": return DecoratorKind.Extension;
+            case "metaextension": return DecoratorKind.MetaExtension;
+            case "customconstructor": return DecoratorKind.CustomConstructor;
+            case "compilemembersonly": return DecoratorKind.CompileMembersOnly;
+            case "pureabstract": return DecoratorKind.PureAbstract;
+            case "phantom": return DecoratorKind.Phantom;
+            case "tuplereturn": return DecoratorKind.TupleReturn;
+            case "noclassor": return DecoratorKind.NoClassOr;
+        }
+
+        return undefined;
+    }
+
     public kind: DecoratorKind;
     public args: string[];
 
-    constructor(raw: string) {
-        let nameEnd = raw.indexOf(" ");
-        if (nameEnd === -1) {
-            nameEnd = raw.length;
-        }
-        this.kind = DecoratorKind[raw.substring(0, nameEnd)];
-        this.args = raw.split(" ").slice(1);
+    constructor(name: string, args: string[]) {
+        this.kind = Decorator.getDecoratorKind(name);
+        this.args = args;
     }
 }
 

--- a/src/Decorator.ts
+++ b/src/Decorator.ts
@@ -7,7 +7,7 @@ export class Decorator {
         if (nameEnd === -1) {
             nameEnd = raw.length;
         }
-        this.kind = DecoratorKind[raw.substring(1, nameEnd)];
+        this.kind = DecoratorKind[raw.substring(0, nameEnd)];
         this.args = raw.split(" ").slice(1);
     }
 }

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -120,6 +120,8 @@ export class TSHelper {
                 const dec = new Decorator(decStr.substr(1));
                 if (dec.kind !== undefined) {
                     decMap.set(dec.kind, dec);
+                    console.warn(`[Deprecated] Decorators with ! are being deprecated, `
+                        + `use @${decStr.substr(1)} instead`);
                 } else {
                     console.warn(`Encountered unknown decorator ${decStr}.`);
                 }

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -109,14 +109,29 @@ export class TSHelper {
             const comments = type.symbol.getDocumentationComment(checker);
             const decorators =
                 comments.filter(comment => comment.kind === "text")
-                        .map(comment => comment.text.trim().split("\n"))
+                        .map(comment => comment.text.split("\n"))
                         .reduce((a, b) => a.concat(b), [])
+                        .map(line => line.trim())
                         .filter(comment => comment[0] === "!");
+
             const decMap = new Map<DecoratorKind, Decorator>();
+
             decorators.forEach(decStr => {
-                const dec = new Decorator(decStr);
-                decMap.set(dec.kind, dec);
+                const dec = new Decorator(decStr.substr(1));
+                if (dec.kind !== undefined) {
+                    decMap.set(dec.kind, dec);
+                } else {
+                    console.warn(`Encountered unknown decorator ${decStr}.`);
+                }
             });
+
+            type.symbol.getJsDocTags().forEach(tag => {
+                const dec = new Decorator(tag.name);
+                if (dec.kind !== undefined) {
+                    decMap.set(dec.kind, dec);
+                }
+            });
+
             return decMap;
         }
         return new Map<DecoratorKind, Decorator>();

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -117,8 +117,9 @@ export class TSHelper {
             const decMap = new Map<DecoratorKind, Decorator>();
 
             decorators.forEach(decStr => {
-                const dec = new Decorator(decStr.substr(1));
-                if (dec.kind !== undefined) {
+                const [decoratorName, ...decoratorArguments] = decStr.split(" ");
+                if (Decorator.isValid(decoratorName.substr(1))) {
+                    const dec = new Decorator(decoratorName.substr(1), decoratorArguments);
                     decMap.set(dec.kind, dec);
                     console.warn(`[Deprecated] Decorators with ! are being deprecated, `
                         + `use @${decStr.substr(1)} instead`);
@@ -128,8 +129,8 @@ export class TSHelper {
             });
 
             type.symbol.getJsDocTags().forEach(tag => {
-                const dec = new Decorator(tag.name);
-                if (dec.kind !== undefined) {
+                if (Decorator.isValid(tag.name)) {
+                    const dec = new Decorator(tag.name, tag.text.split(" "));
                     decMap.set(dec.kind, dec);
                 }
             });

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -130,7 +130,7 @@ export class TSHelper {
 
             type.symbol.getJsDocTags().forEach(tag => {
                 if (Decorator.isValid(tag.name)) {
-                    const dec = new Decorator(tag.name, tag.text.split(" "));
+                    const dec = new Decorator(tag.name, tag.text ? tag.text.split(" ") : []);
                     decMap.set(dec.kind, dec);
                 }
             });

--- a/src/lualib/StringReplace.ts
+++ b/src/lualib/StringReplace.ts
@@ -1,5 +1,5 @@
 declare namespace string {
-    /** !TupleReturn */
+    /** @tupleReturn */
     function gsub(source: string, searchValue: string, replaceValue: string): [string, number];
 }
 

--- a/test/runner.ts
+++ b/test/runner.ts
@@ -1,5 +1,4 @@
 import { TestRunner, TestSet } from "alsatian";
-import { TapBark } from "tap-bark";
 
 import * as fs from "fs";
 import * as path from "path";
@@ -21,9 +20,6 @@ fs.copyFileSync(
 
 // setup the output
 testRunner.outputStream
-          // this will use alsatian's default output if you remove this
-          // you'll get TAP or you can add your favourite TAP reporter in it's place
-          .pipe(TapBark.create().getPipeable())
           // pipe to the console
           .pipe(process.stdout);
 

--- a/test/runner.ts
+++ b/test/runner.ts
@@ -34,4 +34,7 @@ testRunner.run(testSet)
           .catch(error => {
               // Remove lualib bundle again
               fs.unlinkSync("lualib_bundle.lua");
+
+              console.error(error);
+              process.exit(1);
           });

--- a/test/translation/ts/assignments.ts
+++ b/test/translation/ts/assignments.ts
@@ -10,7 +10,7 @@ declare function getIndex(): number;
 declare let xTup: [number, number];
 declare let yTup: [number, number];
 declare function getTup(): [number, number];
-/** !TupleReturn */
+/** @tupleReturn */
 declare function getTupRet(): [number, number];
 x = y;
 x = obj.prop;

--- a/test/translation/ts/classExtension1.ts
+++ b/test/translation/ts/classExtension1.ts
@@ -1,4 +1,4 @@
-/** !Extension */
+/** @extension */
 class MyClass {
     public myFunction() {}
 }

--- a/test/translation/ts/classExtension2.ts
+++ b/test/translation/ts/classExtension2.ts
@@ -1,8 +1,8 @@
-/** !Extension */
+/** @extension */
 class TestClass {
 }
 
-/** !Extension */
+/** @extension */
 class MyClass extends TestClass {
     public myFunction() {}
 }

--- a/test/translation/ts/classExtension3.ts
+++ b/test/translation/ts/classExtension3.ts
@@ -1,9 +1,9 @@
-/** !Extension RenamedTestClass */
+/** @extension RenamedTestClass */
 class TestClass {
     public myFunction() {}
 }
 
-/** !Extension RenamedMyClass */
+/** @extension RenamedMyClass */
 class MyClass extends TestClass {
     public myFunction() {}
 }

--- a/test/translation/ts/classExtension4.ts
+++ b/test/translation/ts/classExtension4.ts
@@ -1,4 +1,4 @@
-/** !Extension */
+/** @extension */
 class MyClass {
     public test: string = "test";
     private testP: string = "testP";

--- a/test/translation/ts/classPureAbstract.ts
+++ b/test/translation/ts/classPureAbstract.ts
@@ -1,3 +1,3 @@
-/** !PureAbstract */
+/** @pureAbstract */
 declare class ClassA {}
 class ClassB extends ClassA {}

--- a/test/translation/ts/enumMembersOnly.ts
+++ b/test/translation/ts/enumMembersOnly.ts
@@ -1,4 +1,4 @@
-/** !CompileMembersOnly */
+/** @compileMembersOnly */
 enum TestEnum {
     val1 = 0,
     val2 = 2,

--- a/test/translation/ts/enumMembersOnly.ts
+++ b/test/translation/ts/enumMembersOnly.ts
@@ -3,7 +3,7 @@ enum TestEnum {
     val1 = 0,
     val2 = 2,
     val3,
-    val4 = "bye"
+    val4 = "bye",
 }
 
 const a = TestEnum.val1;

--- a/test/translation/ts/namespacePhantom.ts
+++ b/test/translation/ts/namespacePhantom.ts
@@ -1,4 +1,4 @@
-/** !Phantom */
+/** @phantom */
 namespace myNamespace {
     function nsMember() {}
 }

--- a/test/translation/ts/tupleReturn.ts
+++ b/test/translation/ts/tupleReturn.ts
@@ -1,4 +1,4 @@
-/** !TupleReturn */
+/** @tupleReturn */
 function tupleReturn(): [number, string] {
     return [0, "foobar"];
 }
@@ -16,19 +16,19 @@ e = tupleReturn();
 f = noTupleReturn();
 foo(tupleReturn());
 foo(noTupleReturn());
-/** !TupleReturn */
+/** @tupleReturn */
 function tupleReturnFromVar(): [number, string] {
     const r: [number, string] = [1, "baz"];
     return r;
 }
-/** !TupleReturn */
+/** @tupleReturn */
 function tupleReturnForward(): [number, string] {
     return tupleReturn();
 }
 function tupleNoForward(): [number, string] {
     return tupleReturn();
 }
-/** !TupleReturn */
+/** @tupleReturn */
 function tupleReturnUnpack(): [number, string] {
     return tupleNoForward();
 }

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -76,7 +76,7 @@ export class AssignmentTests {
 
     @Test("TupleReturn assignment")
     public tupleReturnFunction(): void {
-        const code = `/** !TupleReturn */\n`
+        const code = `/** @tupleReturn */\n`
                    + `declare function abc() { return [1,2,3]; }\n`
                    + `let [a,b] = abc();`;
 
@@ -86,7 +86,7 @@ export class AssignmentTests {
 
     @Test("TupleReturn Single assignment")
     public tupleReturnSingleAssignment(): void {
-        const code = `/** !TupleReturn */\n`
+        const code = `/** @tupleReturn */\n`
                    + `declare function abc(): [number, string]; }\n`
                    + `let a = abc();`
                    + `a = abc();`;
@@ -98,7 +98,7 @@ export class AssignmentTests {
     @Test("TupleReturn interface assignment")
     public tupleReturnInterface(): void {
         const code = `interface def {\n`
-                   + `/** !TupleReturn */\n`
+                   + `/** @tupleReturn */\n`
                    + `abc();\n`
                    + `} declare const jkl : def;\n`
                    + `let [a,b] = jkl.abc();`;
@@ -110,7 +110,7 @@ export class AssignmentTests {
     @Test("TupleReturn namespace assignment")
     public tupleReturnNameSpace(): void {
         const code = `declare namespace def {\n`
-                   + `/** !TupleReturn */\n`
+                   + `/** @tupleReturn */\n`
                    + `function abc() {}\n`
                    + `}\n`
                    + `let [a,b] = def.abc();`;
@@ -122,7 +122,7 @@ export class AssignmentTests {
     @Test("TupleReturn method assignment")
     public tupleReturnMethod(): void {
         const code = `declare class def {\n`
-                   + `/** !TupleReturn */\n`
+                   + `/** @tupleReturn */\n`
                    + `abc() { return [1,2,3]; }\n`
                    + `} const jkl = new def();\n`
                    + `let [a,b] = jkl.abc();`;
@@ -133,7 +133,7 @@ export class AssignmentTests {
 
     @Test("TupleReturn functional")
     public tupleReturnFunctional(): void {
-        const code = `/** !TupleReturn */
+        const code = `/** @tupleReturn */
         function abc(): [number, string] { return [3, "a"]; }
         const [a, b] = abc();
         return b + a;`;
@@ -147,7 +147,7 @@ export class AssignmentTests {
 
     @Test("TupleReturn single")
     public tupleReturnSingle(): void {
-        const code = `/** !TupleReturn */
+        const code = `/** @tupleReturn */
         function abc(): [number, string] { return [3, "a"]; }
         const res = abc();
         return res.length`;
@@ -161,7 +161,7 @@ export class AssignmentTests {
 
     @Test("TupleReturn in expression")
     public tupleReturnInExpression(): void {
-        const code = `/** !TupleReturn */
+        const code = `/** @tupleReturn */
         function abc(): [number, string] { return [3, "a"]; }
         return abc()[1] + abc()[0];`;
 

--- a/test/unit/decoratorCustomConstructor.spec.ts
+++ b/test/unit/decoratorCustomConstructor.spec.ts
@@ -9,7 +9,7 @@ export class DecoratorCustomConstructor {
     public customCreate(): void {
         // Transpile
         const lua = util.transpileString(
-            `/** !CustomConstructor Point2DCreate */
+            `/** @customConstructor Point2DCreate */
             class Point2D {
                 x: number;
                 y: number;
@@ -29,7 +29,7 @@ export class DecoratorCustomConstructor {
     public incorrectUsage(): void {
         Expect(() => {
             util.transpileString(
-                `/** !CustomConstructor */
+                `/** @customConstructor */
                 class Point2D {
                     x: number;
                     y: number;

--- a/test/unit/decoratorMetaExtension.spec.ts
+++ b/test/unit/decoratorMetaExtension.spec.ts
@@ -14,7 +14,7 @@ export class DecoratorMetaExtension {
             declare namespace debug {
                 function getregistry(): any;
             }
-            /** !MetaExtension */
+            /** @metaExtension */
             class LoadedExt extends _LOADED {
                 public static test() {
                     return 5;
@@ -33,7 +33,7 @@ export class DecoratorMetaExtension {
         Expect(() => {
             util.transpileString(
                 `
-                /** !MetaExtension */
+                /** @metaExtension */
                 class LoadedExt {
                     public static test() {
                         return 5;
@@ -51,7 +51,7 @@ export class DecoratorMetaExtension {
             util.transpileString(
                 `
                 declare class _LOADED;
-                /** !MetaExtension */
+                /** @metaExtension */
                 class Ext extends _LOADED {
                 }
                 const e = new Ext();

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -324,7 +324,7 @@ export class ExpressionTests {
             `let x: [string, string] = ["x0", "x1"];
             let y: [string, string] = ["y0", "y1"];
             function t(): [string, string] { return ["t0", "t1"] };
-            /** !TupleReturn */
+            /** @tupleReturn */
             function tr(): [string, string] { return ["tr0", "tr1"] };
             const r = ${expression};
             return \`\${r[0]},\${r[1]}\``);

--- a/test/unit/tshelper.spec.ts
+++ b/test/unit/tshelper.spec.ts
@@ -42,7 +42,7 @@ export class TSHelperTests {
 
     @Test("GetCustomDecorators single")
     public GetCustomDecoratorsSingle(): void {
-        const source = `/** !CompileMembersOnly */
+        const source = `/** @compileMembersOnly */
             enum TestEnum {
                 val1 = 0,
                 val2 = 2,
@@ -64,8 +64,8 @@ export class TSHelperTests {
 
     @Test("GetCustomDecorators multiple")
     public GetCustomDecoratorsMultiple(): void {
-        const source = `/** !CompileMembersOnly
-            * !Phantom */
+        const source = `/** @compileMembersOnly
+            * @Phantom */
             enum TestEnum {
                 val1 = 0,
                 val2 = 2,
@@ -88,7 +88,7 @@ export class TSHelperTests {
 
     @Test("GetCustomDecorators single jsdoc")
     public GetCustomDecoratorsSingleJSDoc(): void {
-        const source = `/** @CompileMembersOnly */
+        const source = `/** @compileMembersOnly */
             enum TestEnum {
                 val1 = 0,
                 val2 = 2,
@@ -110,7 +110,7 @@ export class TSHelperTests {
 
     @Test("GetCustomDecorators multiple jsdoc")
     public GetCustomDecoratorsMultipleJSDoc(): void {
-        const source = `/** @Phantom
+        const source = `/** @phantom
             * @CompileMembersOnly */
             enum TestEnum {
                 val1 = 0,
@@ -136,8 +136,8 @@ export class TSHelperTests {
     public GetCustomDecoratorsMultipleDefaultJSDoc(): void {
         const source = `/**
             * @description abc
-            * @Phantom
-            * @CompileMembersOnly */
+            * @phantom
+            * @compileMembersOnly */
             enum TestEnum {
                 val1 = 0,
                 val2 = 2,

--- a/test/unit/tshelper.spec.ts
+++ b/test/unit/tshelper.spec.ts
@@ -135,8 +135,7 @@ export class TSHelperTests {
     @Test("GetCustomDecorators multiple default jsdoc")
     public GetCustomDecoratorsMultipleDefaultJSDoc(): void {
         const source = `/**
-            * @description
-            * @param abc def
+            * @description abc
             * @Phantom
             * @CompileMembersOnly */
             enum TestEnum {

--- a/test/unit/tuples.spec.ts
+++ b/test/unit/tuples.spec.ts
@@ -82,7 +82,7 @@ export class TupleTests {
     public tupleDestruct(): void {
         // Transpile
         const lua = util.transpileString(
-            `function tuple(): [number, number, number] { return [3,5,1]; }\n
+            `function tuple(): [number, number, number] { return [3,5,1]; }
             const [a,b,c] = tuple();
             return b;`
         );
@@ -113,8 +113,8 @@ export class TupleTests {
     public tupleReturnAccess(): void {
         // Transpile
         const lua = util.transpileString(
-            `/** !TupleReturn */\n
-            function tuple(): [number, number, number] { return [3,5,1]; }\n
+            `/** @tupleReturn */
+            function tuple(): [number, number, number] { return [3,5,1]; }
             return tuple()[2];`
         );
 
@@ -129,8 +129,8 @@ export class TupleTests {
     public tupleReturnDestructDeclaration(): void {
         // Transpile
         const lua = util.transpileString(
-            `/** !TupleReturn */\n
-            function tuple(): [number, number, number] { return [3,5,1]; }\n
+            `/** @tupleReturn */
+            function tuple(): [number, number, number] { return [3,5,1]; }
             const [a,b,c] = tuple();
             return b;`
         );
@@ -146,8 +146,8 @@ export class TupleTests {
     public tupleReturnDestructAssignment(): void {
         // Transpile
         const lua = util.transpileString(
-            `/** !TupleReturn */\n
-            function tuple(): [number, number] { return [3,6]; }\n
+            `/** @tupleReturn */
+            function tuple(): [number, number] { return [3,6]; }
             const [a,b] = [1,2];
             [b,a] = tuple();
             return a - b;`
@@ -164,10 +164,10 @@ export class TupleTests {
     public tupleStaticMethodReturnDestruct(): void {
         // Transpile
         const lua = util.transpileString(
-            `class Test {\n
-                /** !TupleReturn */\n
-                static tuple(): [number, number, number] { return [3,5,1]; }\n
-            }\n
+            `class Test {
+                /** @tupleReturn */
+                static tuple(): [number, number, number] { return [3,5,1]; }
+            }
             const [a,b,c] = Test.tuple();
             return b;`
         );
@@ -183,10 +183,10 @@ export class TupleTests {
     public tupleMethodNonStaticReturnDestruct(): void {
         // Transpile
         const lua = util.transpileString(
-            `class Test {\n
-                /** !TupleReturn */\n
-                tuple(): [number, number, number] { return [3,5,1]; }\n
-            }\n
+            `class Test {
+                /** @tupleReturn */
+                tuple(): [number, number, number] { return [3,5,1]; }
+            }
             const t = new Test();
             const [a,b,c] = t.tuple();
             return b;`


### PR DESCRIPTION
Added the ability to define decorators like JSDoc annotations. Left the old decorators in for now to stay backwards compatible.

I'm planning on updating documentation once this is merged to only mention the `@` decorators. Before v1 releasees we should remove the old decorators, and probably rename to 'annotations' or something similar.