### PR TITLE
Check inherited accessors

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -81,14 +81,14 @@ export class TSHelper {
     }
 
     // iterate over a type and its bases until the callback returns true.
-    public static forAllTypes(type: ts.Type, callback: (type: ts.Type) => boolean): boolean {
+    public static forTypeOrAnySupertype(type: ts.Type, callback: (type: ts.Type) => boolean): boolean {
         if (callback(type)) {
             return true;
         }
         const baseTypes = type.getBaseTypes();
         if (baseTypes) {
             for (const baseType of baseTypes) {
-                if (this.forAllTypes(baseType, callback)) {
+                if (this.forTypeOrAnySupertype(baseType, callback)) {
                     return true;
                 }
             }
@@ -115,7 +115,7 @@ export class TSHelper {
     }
 
     public static isArrayType(type: ts.Type, checker: ts.TypeChecker): boolean {
-        return this.forAllTypes(type, t => this.isExplicitArrayType(t, checker));
+        return this.forTypeOrAnySupertype(type, t => this.isExplicitArrayType(t, checker));
     }
 
     public static isTupleReturnCall(node: ts.Node, checker: ts.TypeChecker): boolean {
@@ -203,7 +203,7 @@ export class TSHelper {
         if (ts.isPropertyAccessExpression(node)) {
             const name = node.name.escapedText;
             const type = checker.getTypeAtLocation(node.expression);
-            return this.forAllTypes(type, t => this.hasExplicitGetAccessor(t, name));
+            return this.forTypeOrAnySupertype(type, t => this.hasExplicitGetAccessor(t, name));
         }
         return false;
     }
@@ -219,7 +219,7 @@ export class TSHelper {
         if (ts.isPropertyAccessExpression(node)) {
             const name = node.name.escapedText;
             const type = checker.getTypeAtLocation(node.expression);
-            return this.forAllTypes(type, t => this.hasExplicitSetAccessor(t, name));
+            return this.forTypeOrAnySupertype(type, t => this.hasExplicitSetAccessor(t, name));
         }
         return false;
     }

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -80,6 +80,22 @@ export class TSHelper {
             || (ts.isBinaryExpression(node.parent) && ts.isArrayLiteralExpression(node.parent.left)));
     }
 
+    // iterate over a type and its bases until the callback returns true.
+    public static forAllTypes(type: ts.Type, callback: (type: ts.Type) => boolean): boolean {
+        if (callback(type)) {
+            return true;
+        }
+        const baseTypes = type.getBaseTypes();
+        if (baseTypes) {
+            for (const baseType of baseTypes) {
+                if (this.forAllTypes(baseType, callback)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     public static isStringType(type: ts.Type): boolean {
         return (type.flags & ts.TypeFlags.String) !== 0
             || (type.flags & ts.TypeFlags.StringLike) !== 0
@@ -181,22 +197,6 @@ export class TSHelper {
             const field = type.symbol.members.get(name);
             return field && (field.flags & ts.SymbolFlags.GetAccessor) !== 0;
         }
-    }
-
-    // iterate over a type and its bases until the callback returns true.
-    public static forAllTypes(type: ts.Type, callback: (type: ts.Type) => boolean): boolean {
-        if (callback(type)) {
-            return true;
-        }
-        const baseTypes = type.getBaseTypes();
-        if (baseTypes) {
-            for (const baseType of baseTypes) {
-                if (this.forAllTypes(baseType, callback)) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     public static hasGetAccessor(node: ts.Node, checker: ts.TypeChecker): boolean {

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -1,11 +1,10 @@
-import { Expect, Test, TestCase, FocusTests } from "alsatian";
+import { Expect, Test, TestCase } from "alsatian";
 import { TranspileError } from "../../src/Errors";
 import { LuaTarget } from "../../src/Transpiler";
 
 import * as ts from "typescript";
 import * as util from "../src/util";
 
-@FocusTests
 export class ExpressionTests {
 
     @TestCase("i++", "i = (i+1);")

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -1,10 +1,11 @@
-import { Expect, Test, TestCase } from "alsatian";
+import { Expect, Test, TestCase, FocusTests } from "alsatian";
 import { TranspileError } from "../../src/Errors";
 import { LuaTarget } from "../../src/Transpiler";
 
 import * as ts from "typescript";
 import * as util from "../src/util";
 
+@FocusTests
 export class ExpressionTests {
 
     @TestCase("i++", "i = (i+1);")
@@ -254,9 +255,9 @@ export class ExpressionTests {
         Expect(result).toBe(expected);
     }
 
-    @TestCase("inst.baseField", 10)
-    @TestCase("inst.field", 8)
-    @TestCase("inst.superField", 6)
+    @TestCase("inst.baseField", 7)
+    @TestCase("inst.field", 6)
+    @TestCase("inst.superField", 5)
     @Test("Inherited accessors")
     public inheritedAccessors(expression: string, expected: any): void {
       const source = `class MyBaseClass {`
@@ -275,9 +276,9 @@ export class ExpressionTests {
                    + `    public set superField(v: number) { this._superField = v; }`
                    + `}`                   
                    + `var inst = new MySuperClass();`
-                   + `inst.baseField = 4;`
-                   + `inst.field = 4;`
-                   + `inst.superField = 4;`
+                   + `inst.baseField = 1;`
+                   + `inst.field = 2;`
+                   + `inst.superField = 3;`
                    + `return ${expression};`;
 
         const lua = util.transpileString(source);

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -254,6 +254,37 @@ export class ExpressionTests {
         Expect(result).toBe(expected);
     }
 
+    @TestCase("inst.baseField", 10)
+    @TestCase("inst.field", 8)
+    @TestCase("inst.superField", 6)
+    @Test("Inherited accessors")
+    public inheritedAccessors(expression: string, expected: any): void {
+      const source = `class MyBaseClass {`
+                   + `    public _baseField: number;`
+                   + `    public get baseField(): number { return this._baseField + 6; }`
+                   + `    public set baseField(v: number) { this._baseField = v; }`
+                   + `}`
+                   + `class MyClass extends MyBaseClass {`
+                   + `    public _field: number;`
+                   + `    public get field(): number { return this._field + 4; }`
+                   + `    public set field(v: number) { this._field = v; }`
+                   + `}`                   
+                   + `class MySuperClass extends MyClass {`
+                   + `    public _superField: number;`
+                   + `    public get superField(): number { return this._superField + 2; }`
+                   + `    public set superField(v: number) { this._superField = v; }`
+                   + `}`                   
+                   + `var inst = new MySuperClass();`
+                   + `inst.baseField = 4;`
+                   + `inst.field = 4;`
+                   + `inst.superField = 4;`
+                   + `return ${expression};`;
+
+        const lua = util.transpileString(source);
+        const result = util.executeLua(lua);
+        Expect(result).toBe(expected);
+    }
+
     @TestCase("i++", 10)
     @TestCase("i--", 10)
     @TestCase("++i", 11)


### PR DESCRIPTION
Iterate the base classes to find inherited accessor methods. The following code will now correctly transpile:

```
class MyBaseClass {
     private _field: number;
     public get field(): number { return this._field; }
     public set field(v: number) { this._field = v; }
}

class MyClass extends MyBaseClass {
}        

let inst = new MyClass();
inst.field = 5;
```