### PR TITLE
support in transformer for assignments

### DIFF
--- a/src/LuaNode.ts
+++ b/src/LuaNode.ts
@@ -1,0 +1,14 @@
+import * as ts from "typescript";
+
+export enum LuaSyntaxKind {
+    ConcatExpression = 10000,
+    FunctionCallExpression,
+    MethodCallExpression,
+}
+
+export interface LuaNode extends ts.Node {
+    luaKind: LuaSyntaxKind;
+}
+
+export type LuaConcatExpression = LuaNode & ts.BinaryExpression;
+export type LuaCallExpression = LuaNode & ts.CallExpression;

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -1,7 +1,6 @@
 import * as ts from "typescript";
 import { Decorator, DecoratorKind } from "./Decorator";
 import { TSTLErrors } from "./Errors";
-import { LuaCallExpression, LuaConcatExpression, LuaNode, LuaSyntaxKind } from "./LuaNode";
 
 export class TSHelper {
 
@@ -222,11 +221,11 @@ export class TSHelper {
         return [false, null];
     }
 
-    public static isNonCompoundPrefixUnaryOperator(node: ts.PrefixUnaryExpression): boolean {
-        return node.operator === ts.SyntaxKind.ExclamationToken
-               || node.operator === ts.SyntaxKind.MinusToken
-               || node.operator === ts.SyntaxKind.PlusToken
-               || node.operator === ts.SyntaxKind.TildeToken;
+    public static isCompoundPrefixUnaryOperator(node: ts.PrefixUnaryExpression): boolean {
+        return node.operator !== ts.SyntaxKind.ExclamationToken
+               && node.operator !== ts.SyntaxKind.MinusToken
+               && node.operator !== ts.SyntaxKind.PlusToken
+               && node.operator !== ts.SyntaxKind.TildeToken;
     }
 
     public static getUnaryCompoundAssignmentOperator(node: ts.PrefixUnaryExpression | ts.PostfixUnaryExpression)
@@ -246,24 +245,6 @@ export class TSHelper {
         return node.parent === undefined
             || ts.isExpressionStatement(node.parent)
             || ts.isForStatement(node.parent);
-    }
-
-    public static createLuaConcatExpression(left: ts.Expression, right: ts.Expression): LuaConcatExpression {
-        const node = ts.createAdd(left, right) as LuaConcatExpression;
-        node.luaKind = LuaSyntaxKind.ConcatExpression;
-        return node;
-    }
-
-    public static createLuaCallExpression(expression: ts.Expression,
-                                          argumentsArray: ReadonlyArray<ts.Expression>,
-                                          isMethod: boolean): LuaCallExpression {
-        const node = ts.createCall(expression, undefined, argumentsArray) as LuaCallExpression;
-        node.luaKind = isMethod ? LuaSyntaxKind.MethodCallExpression : LuaSyntaxKind.FunctionCallExpression;
-        return node;
-    }
-
-    public static isLuaNode<T extends ts.Node>(node: T): node is LuaNode & T {
-        return (node as LuaNode & T).luaKind !== undefined;
     }
 
     public static isInGlobalScope(node: ts.FunctionDeclaration): boolean {

--- a/src/TransformHelper.ts
+++ b/src/TransformHelper.ts
@@ -1,4 +1,5 @@
 import * as ts from "typescript";
+import { LuaCallExpression, LuaConcatExpression, LuaNode, LuaSyntaxKind } from "./LuaNode";
 
 export class TransformHelper {
     // Helper to create simple lua variable statement;
@@ -16,6 +17,24 @@ export class TransformHelper {
         const requireCall =
             ts.createCall(requireIdentifier, [ts.createLiteralTypeNode(moduleSpecifier)], [moduleSpecifier]);
         return this.createLuaVariableStatement(identifier, requireCall);
+    }
+
+    public static createLuaConcatExpression(left: ts.Expression, right: ts.Expression): LuaConcatExpression {
+        const node = ts.createAdd(left, right) as LuaConcatExpression;
+        node.luaKind = LuaSyntaxKind.ConcatExpression;
+        return node;
+    }
+
+    public static createLuaCallExpression(expression: ts.Expression,
+                                          argumentsArray: ReadonlyArray<ts.Expression>,
+                                          isMethod: boolean): LuaCallExpression {
+        const node = ts.createCall(expression, undefined, argumentsArray) as LuaCallExpression;
+        node.luaKind = isMethod ? LuaSyntaxKind.MethodCallExpression : LuaSyntaxKind.FunctionCallExpression;
+        return node;
+    }
+
+    public static isLuaNode<T extends ts.Node>(node: T): node is LuaNode & T {
+        return (node as LuaNode & T).luaKind !== undefined;
     }
 
     public static flatten<T>(arr: T[]): T[] {

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -10,6 +10,7 @@ import { LuaSyntaxKind } from "./LuaNode";
 import { TSHelper as tsHelper } from "./TSHelper";
 
 import { LuaTransformer } from "./Transformer";
+import { TransformHelper as transformHelper } from "./TransformHelper";
 
 /* tslint:disable */
 const packageJSON = require("../package.json");
@@ -715,7 +716,7 @@ export abstract class LuaTranspiler {
                     // Replace string + with ..
                     const typeLeft = this.checker.getTypeAtLocation(node.left);
                     const typeRight = this.checker.getTypeAtLocation(node.right);
-                    if ((tsHelper.isLuaNode(node) && node.luaKind === LuaSyntaxKind.ConcatExpression)
+                    if ((transformHelper.isLuaNode(node) && node.luaKind === LuaSyntaxKind.ConcatExpression)
                         || (typeLeft.flags & ts.TypeFlags.String) || ts.isStringLiteral(node.left)
                         ||  (typeRight.flags & ts.TypeFlags.String) || ts.isStringLiteral(node.right)) {
                         return lhs + " .. " + rhs;
@@ -1057,7 +1058,7 @@ export abstract class LuaTranspiler {
         if ((functionType.symbol && !(functionType.symbol.flags & ts.SymbolFlags.Method))
             // Check explicitly for method calls on 'this', since they don't have the Method flag set
             || (expression.expression.kind === ts.SyntaxKind.ThisType)
-            || (tsHelper.isLuaNode(node) && node.luaKind === LuaSyntaxKind.FunctionCallExpression)) {
+            || (transformHelper.isLuaNode(node) && node.luaKind === LuaSyntaxKind.FunctionCallExpression)) {
             callPath = this.transpileExpression(expression);
             params = this.transpileArguments(node.arguments);
             return `${callPath}(${params})`;


### PR DESCRIPTION
Everything works (tests are passing), but this could probably use some cleanup/refactoring.

Note, I had to do some split code paths to deal with statements vs expressions.

I noticed in the TS source, operators like +=, -=, etc... are referred to as 'compound assignment operators" so I'm sticking with that terminology for those.
