### PR TITLE
Fixed default constructor on subclass

### DIFF
--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1789,7 +1789,7 @@ export abstract class LuaTranspiler {
         if (constructor) {
             // Add constructor plus initialization of instance fields
             result += this.transpileConstructor(constructor, className);
-        } else if (!isExtension) {
+        } else if (!isExtension && !extendsType) {
             // Generate a constructor if none was defined
             result += this.transpileConstructor(ts.createConstructor([], [], [], ts.createBlock([], true)),
                                                 className);

--- a/test/unit/class.spec.ts
+++ b/test/unit/class.spec.ts
@@ -127,6 +127,59 @@ export class ClassTests {
         Expect(result).toBe(4);
     }
 
+    @Test("SubclassDefaultConstructor")
+    public subclassDefaultConstructor(): void {
+        const result = util.transpileAndExecute(
+            `class a {
+                field: number;
+                constructor(field: number) {
+                    this.field = field;
+                }
+            }
+            class b extends a {}
+            return new b(10).field;`
+        );
+
+        Expect(result).toBe(10);
+    }
+
+    @Test("SubsubclassDefaultConstructor")
+    public subsubclassDefaultConstructor(): void {
+        const result = util.transpileAndExecute(
+            `class a {
+                field: number;
+                constructor(field: number) {
+                    this.field = field;
+                }
+            }
+            class b extends a {}
+            class c extends b {}
+            return new c(10).field;`
+        );
+
+        Expect(result).toBe(10);
+    }
+
+    @Test("SubclassConstructor")
+    public subclassConstructor(): void {
+        const result = util.transpileAndExecute(
+            `class a {
+                field: number;
+                constructor(field: number) {
+                    this.field = field;
+                }
+            }
+            class b extends a {
+                constructor(field: number) {
+                    super(field + 1);
+                }
+            }
+            return new b(10).field;`
+        );
+
+        Expect(result).toBe(11);
+    }
+
     @Test("classSuper")
     public classSuper(): void {
         // Transpile


### PR DESCRIPTION
This addresses #288 
My solution was to simply write no constructor in the subclass if the user hasn't written any constructor. That way, the superclass constructor will be used when constructing the instance.

This was a one-liner, but I added some tests to make sure everything is working (the first and second tests don't work right now).