### PR TITLE
allow non-default properties with derived array types

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -20,6 +20,10 @@ const defaultArrayCallMethodNames = new Set<string>([
     "join",
 ]);
 
+const defaultArrayPropertyNames = new Set<string>([
+    "length",
+]);
+
 export class TSHelper {
 
     // Reverse lookup of enum key by value
@@ -306,6 +310,10 @@ export class TSHelper {
 
     public static isDefaultArrayCallMethodName(methodName: string): boolean {
         return defaultArrayCallMethodNames.has(methodName);
+    }
+
+    public static isDefaultArrayPropertyName(methodName: string): boolean {
+        return defaultArrayPropertyNames.has(methodName);
     }
 
 }

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -1387,7 +1387,11 @@ export abstract class LuaTranspiler {
             case ts.TypeFlags.StringLiteral:
                 return this.transpileStringProperty(node);
             case ts.TypeFlags.Object:
-                if (tsHelper.isArrayType(type, this.checker)) {
+                if (tsHelper.isExplicitArrayType(type, this.checker)) {
+                    return this.transpileArrayProperty(node);
+                }
+                if (tsHelper.isArrayType(type, this.checker)
+                    && tsHelper.isDefaultArrayPropertyName(this.transpileIdentifier(node.name))) {
                     return this.transpileArrayProperty(node);
                 }
         }

--- a/test/unit/array.spec.ts
+++ b/test/unit/array.spec.ts
@@ -1,4 +1,4 @@
-import { Expect, Test, TestCase } from "alsatian";
+import { Expect, Test, TestCase, FocusTest } from "alsatian";
 import * as util from "../src/util";
 
 export class ArrayTests {
@@ -39,8 +39,10 @@ export class ArrayTests {
         Expect(result).toBe(5);
     }
 
+    @FocusTest
     @TestCase("firstElement()", 3)
     @TestCase("name", "array")
+    @TestCase("length", 1)
     @Test("Derived array access")
     public derivedArrayAccess(member: string, expected: any): void {
         const lua = `local arr = {name="array", firstElement=function(self) return self[1]; end};`

--- a/test/unit/array.spec.ts
+++ b/test/unit/array.spec.ts
@@ -39,16 +39,21 @@ export class ArrayTests {
         Expect(result).toBe(5);
     }
 
+    @TestCase("firstElement()", 3)
+    @TestCase("name", "array")
     @Test("Derived array access")
-    public derivedArrayAccess(): void {
-        const lua = `local arr = {firstElement=function(self) return self[1]; end};`
+    public derivedArrayAccess(member: string, expected: any): void {
+        const lua = `local arr = {name="array", firstElement=function(self) return self[1]; end};`
         +  util.transpileString(
-            `interface CustomArray<T> extends Array<T>{ firstElement():number; };
+            `interface CustomArray<T> extends Array<T>{
+                name:string,
+                firstElement():number;
+            };
             declare const arr: CustomArray<number>;
             arr[0] = 3;
-            return arr.firstElement();`
+            return arr.${member};`
         );
         const result = util.executeLua(lua);
-        Expect(result).toBe(3);
+        Expect(result).toBe(expected);
     }
 }

--- a/test/unit/array.spec.ts
+++ b/test/unit/array.spec.ts
@@ -1,4 +1,4 @@
-import { Expect, Test, TestCase, FocusTest } from "alsatian";
+import { Expect, Test, TestCase } from "alsatian";
 import * as util from "../src/util";
 
 export class ArrayTests {
@@ -39,7 +39,6 @@ export class ArrayTests {
         Expect(result).toBe(5);
     }
 
-    @FocusTest
     @TestCase("firstElement()", 3)
     @TestCase("name", "array")
     @TestCase("length", 1)


### PR DESCRIPTION
Generalises #289 for properties. This will allow working with interfaces that extend `Array<T>` and have member properties. Example:

```
interface NamedArray<T> extends Array<T>{
    name:string,
}
```