### PR TITLE
correctly flagging 'this' as simple expression

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -312,7 +312,7 @@ export class TSHelper {
 
     // Returns true for expressions that may have effects when evaluated
     public static isExpressionWithEvaluationEffect(node: ts.Expression): boolean {
-        return !(ts.isLiteralExpression(node) || ts.isIdentifier(node));
+        return !(ts.isLiteralExpression(node) || ts.isIdentifier(node) || node.kind === ts.SyntaxKind.ThisKeyword);
     }
 
     // If expression is property/element access with possible effects from being evaluated, returns true along with the


### PR DESCRIPTION
Added special case to ensure 'this' is treated as a 'simple' expression when determining how to transpile assignment-expressions.

That means this code:
```ts
this.size++;
```

transpiles to this:
```lua
self.size = (self.size+1);
```

instead of this:
```lua
do local __TS_obj, __TS_index = self, "size"; local __TS_tmp = __TS_obj[__TS_index]; __TS_obj[__TS_index] = (__TS_tmp+(1)); end;
```
