### PR TITLE
correctly passing context to functions accessed as elements

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -40,6 +40,9 @@ export class TSTLErrors {
     public static InvalidPropertyCall = (node: ts.Node) =>
         new TranspileError(`Tried to transpile a non-property call as property call.`, node)
 
+    public static InvalidElementCall = (node: ts.Node) =>
+        new TranspileError(`Tried to transpile a non-element call as an element call.`, node)
+
     public static InvalidThrowExpression = (node: ts.Node) =>
         new TranspileError(`Invalid throw expression, only strings can be thrown.`, node)
 

--- a/test/unit/functions.spec.ts
+++ b/test/unit/functions.spec.ts
@@ -381,4 +381,42 @@ export class FunctionTests {
 
         Expect(result).toBe(s1 === s2);
     }
+
+    @Test("Element access call")
+    public elementAccessCall(): void {
+        const code = `class C {
+            method(s: string) { return s; }
+        }
+        const c = new C();
+        return c['method']("foo");
+        `;
+        const result = util.transpileAndExecute(code);
+        Expect(result).toBe("foo");
+    }
+
+    @Test("Complex element access call")
+    public elementAccessCallComplex(): void {
+        const code = `class C {
+            method(s: string) { return s; }
+        }
+        function getC() { return new C(); }
+        return getC()['method']("foo");
+        `;
+        const result = util.transpileAndExecute(code);
+        Expect(result).toBe("foo");
+    }
+
+    @Test("Complex element access call statement")
+    public elementAccessCallComplexStatement(): void {
+        const code = `let foo: string;
+        class C {
+            method(s: string) { foo = s; }
+        }
+        function getC() { return new C(); }
+        getC()['method']("foo");
+        return foo;
+        `;
+        const result = util.transpileAndExecute(code);
+        Expect(result).toBe("foo");
+    }
 }


### PR DESCRIPTION
fixes #266 

Also has a bit of refactoring in transpileCallExpression()
