### PR TITLE
Custom Iterators

### DIFF
--- a/build_lualib.ts
+++ b/build_lualib.ts
@@ -21,8 +21,9 @@ if (fs.existsSync(bundlePath)) {
   fs.unlinkSync(bundlePath);
 }
 
-let bundle = "";
+let bundle = fs.readFileSync("./dist/lualib/Symbol.lua").toString();
 
-glob.sync("./dist/lualib/*.lua").forEach(fileName => bundle += fs.readFileSync(fileName));
+glob.sync("./dist/lualib/*.lua").filter(fileName => fileName !== "Symbol.lua")
+  .forEach(fileName => bundle += fs.readFileSync(fileName));
 
 fs.writeFileSync(bundlePath, bundle);

--- a/build_lualib.ts
+++ b/build_lualib.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as glob from "glob";
 import {compile} from "./src/Compiler";
+import {LuaLib as luaLib, LuaLibFeature} from "./src/LuaLib";
 
 const bundlePath = "./dist/lualib/lualib_bundle.lua";
 
@@ -15,15 +16,11 @@ compile([
     "--rootDir",
     "./src/lualib",
     ...glob.sync("./src/lualib/*.ts"),
-  ]);
+]);
 
 if (fs.existsSync(bundlePath)) {
-  fs.unlinkSync(bundlePath);
+    fs.unlinkSync(bundlePath);
 }
 
-let bundle = fs.readFileSync("./dist/lualib/Symbol.lua").toString();
-
-glob.sync("./dist/lualib/*.lua").filter(fileName => fileName !== "Symbol.lua")
-  .forEach(fileName => bundle += fs.readFileSync(fileName));
-
+const bundle = luaLib.loadFeatures(Object.keys(LuaLibFeature).map(lib => LuaLibFeature[lib]));
 fs.writeFileSync(bundlePath, bundle);

--- a/src/Decorator.ts
+++ b/src/Decorator.ts
@@ -14,6 +14,7 @@ export class Decorator {
             case "phantom": return DecoratorKind.Phantom;
             case "tuplereturn": return DecoratorKind.TupleReturn;
             case "noclassor": return DecoratorKind.NoClassOr;
+            case "luaiterator": return DecoratorKind.LuaIterator;
         }
 
         return undefined;
@@ -37,4 +38,5 @@ export enum DecoratorKind {
     Phantom = "Phantom",
     TupleReturn = "TupleReturn",
     NoClassOr = "NoClassOr",
+    LuaIterator = "LuaIterator",
 }

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -109,4 +109,11 @@ export class TSTLErrors {
                                       node);
         }
     }
+
+    public static UnsupportedNonDestructuringLuaIterator = (node: ts.Node) => {
+        return new TranspileError("Unsupported use of lua iterator with TupleReturn decorator in for...of statement. "
+                                  + "You must use a destructuring statement to catch results from a lua iterator with "
+                                  + "the TupleReturn decorator.",
+                                  node);
+    }
 }

--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -1,0 +1,60 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export enum LuaLibFeature {
+    ArrayConcat = "ArrayConcat",
+    ArrayEvery = "ArrayEvery",
+    ArrayFilter = "ArrayFilter",
+    ArrayForEach = "ArrayForEach",
+    ArrayIndexOf = "ArrayIndexOf",
+    ArrayMap = "ArrayMap",
+    ArrayPush = "ArrayPush",
+    ArrayReverse = "ArrayReverse",
+    ArrayShift = "ArrayShift",
+    ArrayUnshift = "ArrayUnshift",
+    ArraySort = "ArraySort",
+    ArraySlice = "ArraySlice",
+    ArraySome = "ArraySome",
+    ArraySplice = "ArraySplice",
+    FunctionApply = "FunctionApply",
+    FunctionBind = "FunctionBind",
+    FunctionCall = "FunctionCall",
+    InstanceOf = "InstanceOf",
+    Iterator = "Iterator",
+    Map = "Map",
+    Set = "Set",
+    StringReplace = "StringReplace",
+    StringSplit = "StringSplit",
+    Symbol = "Symbol",
+    Ternary = "Ternary",
+}
+
+const luaLibDependencies: { [lib in LuaLibFeature]?: LuaLibFeature[] } = {
+    Iterator: [LuaLibFeature.Symbol],
+    Map: [LuaLibFeature.InstanceOf, LuaLibFeature.Iterator, LuaLibFeature.Symbol],
+    Set: [LuaLibFeature.InstanceOf, LuaLibFeature.Iterator, LuaLibFeature.Symbol],
+};
+
+export class LuaLib {
+    public static loadFeatures(features: Iterable<LuaLibFeature>): string {
+        let result = "";
+
+        const loadedFeatures = new Set<LuaLibFeature>();
+
+        function load(feature: LuaLibFeature): void {
+            if (!loadedFeatures.has(feature)) {
+                loadedFeatures.add(feature);
+                if (luaLibDependencies[feature]) {
+                    luaLibDependencies[feature].forEach(load);
+                }
+                const featureFile = path.resolve(__dirname, `../dist/lualib/${feature}.lua`);
+                result += fs.readFileSync(featureFile).toString() + "\n";
+            }
+        }
+
+        for (const feature of features) {
+            load(feature);
+        }
+        return result;
+    }
+}

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -138,6 +138,16 @@ export class TSHelper {
         return this.forTypeOrAnySupertype(type, checker, t => this.isExplicitArrayType(t, checker));
     }
 
+    public static isLuaIteratorCall(node: ts.Node, checker: ts.TypeChecker): boolean {
+        if (ts.isCallExpression(node) && node.parent && ts.isForOfStatement(node.parent)) {
+            const type = checker.getTypeAtLocation(node.expression);
+            return this.getCustomDecorators(type, checker)
+                       .has(DecoratorKind.LuaIterator);
+        } else {
+            return false;
+        }
+    }
+
     public static isTupleReturnCall(node: ts.Node, checker: ts.TypeChecker): boolean {
         if (ts.isCallExpression(node)) {
             const type = checker.getTypeAtLocation(node.expression);
@@ -157,7 +167,9 @@ export class TSHelper {
                 checker.getTypeAtLocation(declaration),
                 checker
             );
-            return decorators.has(DecoratorKind.TupleReturn);
+            return decorators.has(DecoratorKind.TupleReturn)
+                // Lua iterators are not 'true' tupleReturn functions as they actually return a function
+                && !decorators.has(DecoratorKind.LuaIterator);
         } else {
             return false;
         }

--- a/src/lualib/Iterator.ts
+++ b/src/lualib/Iterator.ts
@@ -1,0 +1,11 @@
+function __TS__Iterator<T>(iterable: Iterable<T>): () => T {
+    const iterator = iterable[Symbol.iterator]();
+    return () => {
+        const result = iterator.next();
+        if (!result.done) {
+            return result.value;
+        } else {
+            return undefined;
+        }
+    };
+}

--- a/src/lualib/Map.ts
+++ b/src/lualib/Map.ts
@@ -1,3 +1,6 @@
+/** @tupleReturn */
+declare function next<TKey, TValue>(t: { [k: string]: TValue }, index?: TKey): [TKey, TValue];
+
 class Map<TKey, TValue> {
     public size: number;
 
@@ -9,9 +12,7 @@ class Map<TKey, TValue> {
 
         if (other instanceof Map) {
             this.size = other.size;
-            for (const kvp of other.entries()) {
-                this.items[kvp[0] as any] = kvp[1];
-            }
+            other.forEach((v, k) => { this.items[k as any] = v; });
         } else if (other !== undefined) {
             this.size = other.length;
             for (const kvp of other) {
@@ -35,12 +36,21 @@ class Map<TKey, TValue> {
         return contains;
     }
 
-    public entries(): Array<[TKey, TValue]> {
-        const out = [];
-        for (const key in this.items) {
-            out[out.length] = [key, this.items[key]];
-        }
-        return out;
+    public [Symbol.iterator](): IterableIterator<[TKey, TValue]> {
+        return this.entries();
+    }
+
+    public entries(): IterableIterator<[TKey, TValue]> {
+        const items = this.items;
+        let key: TKey;
+        let value: TValue;
+        return {
+            [Symbol.iterator](): IterableIterator<[TKey, TValue]> { return this; },
+            next(): IteratorResult<[TKey, TValue]> {
+                [key, value] = next(items, key);
+                return {done: !key, value: [key, value]};
+            },
+        };
     }
 
     public forEach(callback: (value: TValue, key: TKey, map: Map<TKey, TValue>) => any): void {
@@ -58,12 +68,16 @@ class Map<TKey, TValue> {
         return this.items[key as any] !== undefined;
     }
 
-    public keys(): TKey[] {
-        const out = [];
-        for (const key in this.items) {
-            out[out.length] = key;
-        }
-        return out;
+    public keys(): IterableIterator<TKey> {
+        const items = this.items;
+        let key: TKey;
+        return {
+            [Symbol.iterator](): IterableIterator<TKey> { return this; },
+            next(): IteratorResult<TKey> {
+                [key] = next(items, key);
+                return {done: !key, value: key};
+            },
+        };
     }
 
     public set(key: TKey, value: TValue): Map<TKey, TValue> {
@@ -74,11 +88,16 @@ class Map<TKey, TValue> {
         return this;
     }
 
-    public values(): TValue[] {
-        const out = [];
-        for (const key in this.items) {
-            out[out.length] = this.items[key];
-        }
-        return out;
+    public values(): IterableIterator<TValue> {
+        const items = this.items;
+        let key: TKey;
+        let value: TValue;
+        return {
+            [Symbol.iterator](): IterableIterator<TValue> { return this; },
+            next(): IteratorResult<TValue> {
+                [key, value] = next(items, key);
+                return {done: !key, value};
+            },
+        };
     }
 }

--- a/src/lualib/Map.ts
+++ b/src/lualib/Map.ts
@@ -6,17 +6,29 @@ class Map<TKey, TValue> {
 
     private items: {[key: string]: TValue}; // Type of key is actually TKey
 
-    constructor(other: Map<TKey, TValue> | Array<[TKey, TValue]>) {
+    constructor(other: Iterable<[TKey, TValue]> | Array<[TKey, TValue]>) {
         this.items = {};
         this.size = 0;
 
-        if (other instanceof Map) {
-            this.size = other.size;
-            other.forEach((v, k) => { this.items[k as any] = v; });
-        } else if (other !== undefined) {
-            this.size = other.length;
-            for (const kvp of other) {
-                this.items[kvp[0] as any] = kvp[1];
+        if (other) {
+            const iterable = other as Iterable<[TKey, TValue]>;
+            if (iterable[Symbol.iterator]) {
+                // Iterate manually because Map is compiled with ES5 which doesn't support Iterables in for...of
+                const iterator = iterable[Symbol.iterator]();
+                while (true) {
+                    const result = iterator.next();
+                    if (result.done) {
+                        break;
+                    }
+                    const value: [TKey, TValue] = result.value; // Ensures index is offset when tuple is accessed
+                    this.set(value[0], value[1]);
+                }
+            } else {
+                const arr = other as Array<[TKey, TValue]>;
+                this.size = arr.length;
+                for (const kvp of arr) {
+                    this.items[kvp[0] as any] = kvp[1];
+                }
             }
         }
     }

--- a/src/lualib/Set.ts
+++ b/src/lualib/Set.ts
@@ -6,17 +6,28 @@ class Set<TValue> {
 
     private items: {[key: string]: boolean}; // Key type is actually TValue
 
-    constructor(other: Set<TValue> | TValue[]) {
+    constructor(other: Iterable<TValue> | TValue[]) {
         this.items = {};
         this.size = 0;
 
-        if (other instanceof Set) {
-            this.size = other.size;
-            other.forEach(v => { this.items[v as any] = true; });
-        } else if (other !== undefined) {
-            this.size = other.length;
-            for (const value of other) {
-                this.items[value as any] = true as any;
+        if (other) {
+            const iterable = other as Iterable<TValue>;
+            if (iterable[Symbol.iterator]) {
+                // Iterate manually because Set is compiled with ES5 which doesn't support Iterables in for...of
+                const iterator = iterable[Symbol.iterator]();
+                while (true) {
+                    const result = iterator.next();
+                    if (result.done) {
+                        break;
+                    }
+                    this.add(result.value);
+                }
+            } else {
+                const arr = other as TValue[];
+                this.size = arr.length;
+                for (const value of arr) {
+                    this.items[value as any] = true as any;
+                }
             }
         }
     }

--- a/src/lualib/Set.ts
+++ b/src/lualib/Set.ts
@@ -1,3 +1,6 @@
+/** @tupleReturn */
+declare function next<TKey, TValue>(t: { [k: string]: TValue }, index?: TKey): [TKey, TValue];
+
 class Set<TValue> {
     public size: number;
 
@@ -9,9 +12,7 @@ class Set<TValue> {
 
         if (other instanceof Set) {
             this.size = other.size;
-            for (const value of other.values()) {
-                this.items[value as any] = true as any;
-            }
+            other.forEach(v => { this.items[v as any] = true; });
         } else if (other !== undefined) {
             this.size = other.length;
             for (const value of other) {
@@ -43,12 +44,20 @@ class Set<TValue> {
         return contains;
     }
 
-    public entries(): Array<[TValue, TValue]> {
-        const out = [];
-        for (const key in this.items) {
-            out[out.length] = [key, key];
-        }
-        return out;
+    public [Symbol.iterator](): IterableIterator<TValue> {
+        return this.values();
+    }
+
+    public entries(): IterableIterator<[TValue, TValue]> {
+        const items = this.items;
+        let key: TValue;
+        return {
+            [Symbol.iterator](): IterableIterator<[TValue, TValue]> { return this; },
+            next(): IteratorResult<[TValue, TValue]> {
+                [key] = next(items, key);
+                return {done: !key, value: [key, key]};
+            },
+        };
     }
 
     public forEach(callback: (value: TValue, key: TValue, set: Set<TValue>) => any): void {
@@ -62,19 +71,27 @@ class Set<TValue> {
         return this.items[value as any] === true;
     }
 
-    public keys(): TValue[] {
-        const out = [];
-        for (const key in this.items) {
-            out[out.length] = key;
-        }
-        return out;
+    public keys(): IterableIterator<TValue> {
+        const items = this.items;
+        let key: TValue;
+        return {
+            [Symbol.iterator](): IterableIterator<TValue> { return this; },
+            next(): IteratorResult<TValue> {
+                [key] = next(items, key);
+                return {done: !key, value: key};
+            },
+        };
     }
 
-    public values(): TValue[] {
-        const out = [];
-        for (const key in this.items) {
-            out[out.length] = key;
-        }
-        return out;
+    public values(): IterableIterator<TValue> {
+        const items = this.items;
+        let key: TValue;
+        return {
+            [Symbol.iterator](): IterableIterator<TValue> { return this; },
+            next(): IteratorResult<TValue> {
+                [key] = next(items, key);
+                return {done: !key, value: key};
+            },
+        };
     }
 }

--- a/src/lualib/Symbol.ts
+++ b/src/lualib/Symbol.ts
@@ -1,0 +1,3 @@
+Symbol = {
+    iterator: {},
+} as any;

--- a/src/tstl.ts
+++ b/src/tstl.ts
@@ -19,11 +19,14 @@ export {LuaTranspiler53} from "./targets/Transpiler.53";
 export {LuaTranspilerJIT} from "./targets/Transpiler.JIT";
 
 export {
-    LuaLibFeature,
     LuaLibImportKind,
     LuaTarget,
     LuaTranspiler,
 } from "./Transpiler";
+
+export {
+    LuaLibFeature,
+} from "./LuaLib";
 
 export {
     createTranspiler

--- a/test/translation/lua/forOf.lua
+++ b/test/translation/lua/forOf.lua
@@ -1,6 +1,6 @@
-local __loopVariable0 = {1,2,3,4,5,6,7,8,9,10};
-for i0=1, #__loopVariable0 do
-    local i = __loopVariable0[i0];
+local ____TS_array = {1,2,3,4,5,6,7,8,9,10};
+for ____TS_index=1, #____TS_array do
+    local i = ____TS_array[____TS_index];
     do
     end
     ::__continue0::

--- a/test/unit/class.spec.ts
+++ b/test/unit/class.spec.ts
@@ -22,6 +22,58 @@ export class ClassTests {
         Expect(result).toBe(4);
     }
 
+    @Test("ClassNumericLiteralFieldInitializer")
+    public classNumericLiteralFieldInitializer(): void {
+        // Transpile
+        const lua = util.transpileString(
+            `class a {
+                1: number = 4;
+            }
+            return new a()[1];`
+        );
+
+        // Execute
+        const result = util.executeLua(lua);
+
+        // Assert
+        Expect(result).toBe(4);
+    }
+
+    @Test("ClassStringLiteralFieldInitializer")
+    public classStringLiteralFieldInitializer(): void {
+        // Transpile
+        const lua = util.transpileString(
+            `class a {
+                "field": number = 4;
+            }
+            return new a()["field"];`
+        );
+
+        // Execute
+        const result = util.executeLua(lua);
+
+        // Assert
+        Expect(result).toBe(4);
+    }
+
+    @Test("ClassComputedFieldInitializer")
+    public classComputedFieldInitializer(): void {
+        // Transpile
+        const lua = util.transpileString(
+            `const field: "field" = "field";
+            class a {
+                [field]: number = 4;
+            }
+            return new a()[field];`
+        );
+
+        // Execute
+        const result = util.executeLua(lua);
+
+        // Assert
+        Expect(result).toBe(4);
+    }
+
     @Test("ClassConstructor")
     public classConstructor(): void {
         // Transpile
@@ -102,6 +154,52 @@ export class ClassTests {
         const lua = util.transpileString(
             `class a { static field: number = 4; }
             return a.field;`
+        );
+
+        // Execute
+        const result = util.executeLua(lua);
+
+        // Assert
+        Expect(result).toBe(4);
+    }
+
+    @Test("ClassStaticNumericLiteralFields")
+    public classStaticNumericLiteralFields(): void {
+        // Transpile
+        const lua = util.transpileString(
+            `class a { static 1: number = 4; }
+            return a[1];`
+        );
+
+        // Execute
+        const result = util.executeLua(lua);
+
+        // Assert
+        Expect(result).toBe(4);
+    }
+
+    @Test("ClassStaticStringLiteralFields")
+    public classStaticStringLiteralFields(): void {
+        // Transpile
+        const lua = util.transpileString(
+            `class a { static "field": number = 4; }
+            return a["field"];`
+        );
+
+        // Execute
+        const result = util.executeLua(lua);
+
+        // Assert
+        Expect(result).toBe(4);
+    }
+
+    @Test("ClassStaticComputedFields")
+    public classStaticComputedFields(): void {
+        // Transpile
+        const lua = util.transpileString(
+            `const field: "field" = "field";
+            class a { static [field]: number = 4; }
+            return a[field];`
         );
 
         // Execute
@@ -246,6 +344,67 @@ export class ClassTests {
             }
             let inst = new a();
             return inst.method();`
+        );
+
+        // Execute
+        const result = util.executeLua(lua);
+
+        // Assert
+        Expect(result).toBe(4);
+    }
+
+    @Test("ClassNumericLiteralMethodCall")
+    public classNumericLiteralMethodCall(): void {
+        // Transpile
+        const lua = util.transpileString(
+            `class a {
+                public 1(): number {
+                    return 4;
+                }
+            }
+            let inst = new a();
+            return inst[1]();`
+        );
+
+        // Execute
+        const result = util.executeLua(lua);
+
+        // Assert
+        Expect(result).toBe(4);
+    }
+
+    @Test("ClassStringLiteralMethodCall")
+    public classStringLiteralMethodCall(): void {
+        // Transpile
+        const lua = util.transpileString(
+            `class a {
+                public "method"(): number {
+                    return 4;
+                }
+            }
+            let inst = new a();
+            return inst["method"]();`
+        );
+
+        // Execute
+        const result = util.executeLua(lua);
+
+        // Assert
+        Expect(result).toBe(4);
+    }
+
+    @Test("ClassComputedMethodCall")
+    public classComputedMethodCall(): void {
+        // Transpile
+        const lua = util.transpileString(
+            `const method: "method" = "method";
+            class a {
+                public [method](): number {
+                    return 4;
+                }
+            }
+            let inst = new a();
+            return inst[method]();`
         );
 
         // Execute

--- a/test/unit/enum.spec.ts
+++ b/test/unit/enum.spec.ts
@@ -89,4 +89,14 @@ export class EnumTests {
             );
         }).toThrowError(TranspileError, "Only numeric or string initializers allowed for enums.");
     }
+
+    @Test("String literal name in enum")
+    public stringLiteralNameEnum(): void {
+        const code = `enum TestEnum {
+                ["name"] = "foo"
+            }
+            return TestEnum["name"];`;
+        const result = util.transpileAndExecute(code);
+        Expect(result).toBe("foo");
+    }
 }

--- a/test/unit/functions.spec.ts
+++ b/test/unit/functions.spec.ts
@@ -385,38 +385,41 @@ export class FunctionTests {
     @Test("Element access call")
     public elementAccessCall(): void {
         const code = `class C {
-            method(s: string) { return s; }
+            prop = "bar";
+            method(s: string) { return s + this.prop; }
         }
         const c = new C();
         return c['method']("foo");
         `;
         const result = util.transpileAndExecute(code);
-        Expect(result).toBe("foo");
+        Expect(result).toBe("foobar");
     }
 
     @Test("Complex element access call")
     public elementAccessCallComplex(): void {
         const code = `class C {
-            method(s: string) { return s; }
+            prop = "bar";
+            method(s: string) { return s + this.prop; }
         }
         function getC() { return new C(); }
         return getC()['method']("foo");
         `;
         const result = util.transpileAndExecute(code);
-        Expect(result).toBe("foo");
+        Expect(result).toBe("foobar");
     }
 
     @Test("Complex element access call statement")
     public elementAccessCallComplexStatement(): void {
         const code = `let foo: string;
         class C {
-            method(s: string) { foo = s; }
+            prop = "bar";
+            method(s: string) { foo = s + this.prop; }
         }
         function getC() { return new C(); }
         getC()['method']("foo");
         return foo;
         `;
         const result = util.transpileAndExecute(code);
-        Expect(result).toBe("foo");
+        Expect(result).toBe("foobar");
     }
 }


### PR DESCRIPTION
This adds support for using ES6 Iterables in for...of loops. It also adds a custom decorator 'LuaIterator' to indicate a declared function is actually a proper lua iterator and should be used directly in the transpiled for...in loop.

This feature required a lot of additions and changes:
- New lib function '__TS__Iterator' which is used in place of pairs to iterate Iterables
- New lib 'Symbol' for well-known symbol support (currently only has Symbol.iterator' but more can be added in the future)
- Updated Map and Set libs to use custom iterators
- Updated lib import logic to ensure that dependencies of libs are included before the lib itself
- Forced Symbol lib to be included first in bundle, as Map and Set depend on it
- Support for methods declared with computed names
- Fixed a bug in transpileElementCall that wasn't caught by tests (and updated tests)

Something to note about LuaIterator is that it can be combined TupleReturn:
```ts
/** @luaIterator */
/** @tupleReturn */
declare function luaIter(): Iterable<[string, string]>;
for (let [a, b] of luaIter()) {}
```
```lua
for a, b in luaIter() do
end
```
But if a function is declared this way, the variable(s) in the for...of loop MUST be destructured or an error will be thrown:
```ts
for (let a of luaIter()) {} // Error - 'a' is not destructured
```
This is because there is no straight forward way to represent this in lua. A solution could be to wrap the iterator call in another custom lib function that bundles the results, but this is pretty tricky and I suspect most of the time this error will be hit by accident when the intention was to use the destructured version.
