### PR TITLE
fixed compiler crash when unable to determine signature of function…

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -370,7 +370,9 @@ export class TSHelper {
                     if (i >= 0) {
                         const parentSignature = checker.getResolvedSignature(signatureDeclaration.parent);
                         const parentSignatureDeclaration = parentSignature.getDeclaration();
-                        declType = checker.getTypeAtLocation(parentSignatureDeclaration.parameters[i]);
+                        if (parentSignatureDeclaration) {
+                            declType = checker.getTypeAtLocation(parentSignatureDeclaration.parameters[i]);
+                        }
                     }
                 } else if (ts.isReturnStatement(signatureDeclaration.parent)) {
                     declType = this.getContainingFunctionReturnType(signatureDeclaration.parent, checker);

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -300,6 +300,20 @@ export class AssignmentTests {
         Expect(result).toBe(expectResult);
     }
 
+    @TestCase("s => s", "foo")
+    @TestCase("function(s) { return s; }", "foo")
+    @TestCase("function(this: void, s: string) { return s; }", "foo")
+    @Test("Valid function expression argument with no signature")
+    public validFunctionExpressionArgumentNoSignature(func: string, expectResult: string): void {
+        const code = `${AssignmentTests.funcAssignTestCode}
+                      const takesFunc: any = (fn: (s: string) => string) => {
+                          return (fn as any)("foo");
+                      }
+                      return takesFunc(${func});`;
+        const result = util.transpileAndExecute(code);
+        Expect(result).toBe(expectResult);
+    }
+
     @TestCase("func", "foo+func")
     @TestCase("lambda", "foo+lambda")
     @TestCase("Foo.staticMethod", "foo+staticMethod")


### PR DESCRIPTION
…argument when passing a function expression

Cases like this:
```ts
declare const foo: any;
foo(() => "foo");
```
would cause the compiler to crash when trying to deduce if the passed function expression should have context or not. Now this will fail gracefully and the expression will be assumed to be a non-method.