### PR TITLE
Validation crash fix

### DIFF
--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -91,12 +91,20 @@ export class AssignmentTests {
             .toThrowError(Error, "Ellipsis destruction is not allowed.");
     }
 
+    @Test("Tuple Assignment")
+    public tupleAssignment(): void {
+        const code = `function abc() { return [1, 2]; };
+                      let t: [number, number] = abc();
+                      return t[0] + t[1];`;
+        const result = util.transpileAndExecute(code);
+        Expect(result).toBe(3);
+    }
+
     @Test("TupleReturn assignment")
     public tupleReturnFunction(): void {
         const code = `/** @tupleReturn */\n`
-                   + `function abc() { return [1,2,3]; }\n`
-                   + `let [a,b] = abc();`
-                   + `[a, b] = abc();`;
+                   + `declare function abc(): number[]\n`
+                   + `let [a,b] = abc();`;
 
         const lua = util.transpileString(code);
         Expect(lua).toBe("local a,b=abc();");
@@ -105,7 +113,7 @@ export class AssignmentTests {
     @Test("TupleReturn Single assignment")
     public tupleReturnSingleAssignment(): void {
         const code = `/** @tupleReturn */\n`
-                   + `declare function abc(): [number, string]; }\n`
+                   + `declare function abc(): [number, string];\n`
                    + `let a = abc();`
                    + `a = abc();`;
 

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -94,7 +94,7 @@ export class AssignmentTests {
     @Test("TupleReturn assignment")
     public tupleReturnFunction(): void {
         const code = `/** @tupleReturn */\n`
-                   + `declare function abc() { return [1,2,3]; }\n`
+                   + `function abc() { return [1,2,3]; }\n`
                    + `let [a,b] = abc();`;
 
         const lua = util.transpileString(code);
@@ -104,7 +104,7 @@ export class AssignmentTests {
     @Test("TupleReturn Single assignment")
     public tupleReturnSingleAssignment(): void {
         const code = `/** @tupleReturn */\n`
-                   + `declare function abc(): [number, string]; }\n`
+                   + `function abc(): [number, string]; }\n`
                    + `let a = abc();`
                    + `a = abc();`;
 

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -95,7 +95,8 @@ export class AssignmentTests {
     public tupleReturnFunction(): void {
         const code = `/** @tupleReturn */\n`
                    + `function abc() { return [1,2,3]; }\n`
-                   + `let [a,b] = abc();`;
+                   + `let [a,b] = abc();`
+                   + `[a, b] = abc();`;
 
         const lua = util.transpileString(code);
         Expect(lua).toBe("local a,b=abc();");
@@ -104,7 +105,7 @@ export class AssignmentTests {
     @Test("TupleReturn Single assignment")
     public tupleReturnSingleAssignment(): void {
         const code = `/** @tupleReturn */\n`
-                   + `function abc(): [number, string]; }\n`
+                   + `declare function abc(): [number, string]; }\n`
                    + `let a = abc();`
                    + `a = abc();`;
 


### PR DESCRIPTION
Fixed crash in validateFunctionAssignment cause but certain situations involving arrays/tuples such as this:
```ts
declare function foo(): number[];
let [a, b]: [number, number] = foo();
```

Also fixed ts errors in a couple of tuple assignment tests.
