### PR TITLE
declaring nested functions as local and cleaned up a few small things

### DIFF
--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -308,7 +308,7 @@ export class LuaPrinter {
             paramterArr.push(this.printDotsLiteral(expression.dots));
         }
 
-        let result = this.indent(`function (${paramterArr.join(", ")})\n`);
+        let result = `function (${paramterArr.join(", ")})\n`;
         this.pushIndent();
         result += this.printBlock(expression.body);
         this.popIndent();

--- a/test/translation/lua/functionRestArguments.lua
+++ b/test/translation/lua/functionRestArguments.lua
@@ -1,3 +1,3 @@
 varargsFunction = function (a, ...)
-    b = ({...});
+    local b = ({...});
 end;

--- a/test/translation/lua/methodRestArguments.lua
+++ b/test/translation/lua/methodRestArguments.lua
@@ -10,5 +10,5 @@ end;
 MyClass.constructor = function (self)
 end;
 MyClass.varargsFunction = function (self, a, ...)
-    b = ({...});
+    local b = ({...});
 end;


### PR DESCRIPTION
- nested functions now declared local
- removed incorrect uses of createLocalOrGlobalDeclaration
- removed indentation from beginning of function expressions since they are always assigned to something