### PR TITLE
Fix renamed class extension

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -54,19 +54,25 @@ export class TSHelper {
         return result;
     }
 
-    public static getExtendedType(node: ts.ClassLikeDeclarationBase, checker: ts.TypeChecker): ts.Type | undefined {
+    public static getExtendedTypeNode(node: ts.ClassLikeDeclarationBase, checker: ts.TypeChecker):
+    ts.ExpressionWithTypeArguments | undefined {
         if (node && node.heritageClauses) {
             for (const clause of node.heritageClauses) {
                 if (clause.token === ts.SyntaxKind.ExtendsKeyword) {
                     const superType = checker.getTypeAtLocation(clause.types[0]);
                     const decorators = this.getCustomDecorators(superType, checker);
                     if (!decorators.has(DecoratorKind.PureAbstract)) {
-                        return superType;
+                        return clause.types[0];
                     }
                 }
             }
         }
         return undefined;
+    }
+
+    public static getExtendedType(node: ts.ClassLikeDeclarationBase, checker: ts.TypeChecker): ts.Type | undefined {
+        const extendedTypeNode = this.getExtendedTypeNode(node, checker);
+        return extendedTypeNode && checker.getTypeAtLocation(extendedTypeNode);
     }
 
     public static isFileModule(sourceFile: ts.SourceFile): boolean {

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -2128,7 +2128,7 @@ export abstract class LuaTranspiler {
             result += this.indent + this.accessPrefix(node) + `${className} = ${classOr}{}\n`;
             this.pushExport(className, node);
         } else {
-            const extendedTypeNode = tsHelper.getExtendedTypeNode(node,this.checker);
+            const extendedTypeNode = tsHelper.getExtendedTypeNode(node, this.checker);
             const baseName = this.transpileNode(extendedTypeNode.expression);
             result += this.indent + this.accessPrefix(node) + `${className} = ${classOr}${baseName}.new()\n`;
             this.pushExport(className, node);

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -2128,7 +2128,8 @@ export abstract class LuaTranspiler {
             result += this.indent + this.accessPrefix(node) + `${className} = ${classOr}{}\n`;
             this.pushExport(className, node);
         } else {
-            const baseName = extendsType.symbol.escapedName;
+            const extendedTypeNode = tsHelper.getExtendedTypeNode(node,this.checker);
+            const baseName = this.transpileNode(extendedTypeNode.expression);
             result += this.indent + this.accessPrefix(node) + `${className} = ${classOr}${baseName}.new()\n`;
             this.pushExport(className, node);
         }

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -2135,9 +2135,9 @@ export abstract class LuaTranspiler {
         }
         result += this.indent + `${className}.__index = ${className}\n`;
         if (extendsType) {
-          const extendedTypeNode = tsHelper.getExtendedTypeNode(node, this.checker);
-          const baseName = this.transpileNode(extendedTypeNode.expression);
-          result += this.indent + `${className}.__base = ${baseName}\n`;
+            const extendedTypeNode = tsHelper.getExtendedTypeNode(node, this.checker);
+            const baseName = this.transpileNode(extendedTypeNode.expression);
+            result += this.indent + `${className}.__base = ${baseName}\n`;
         }
         result += this.indent + `function ${className}.new(construct, ...)\n`;
         result += this.indent + `    local self = setmetatable({}, ${className})\n`;

--- a/src/Transpiler.ts
+++ b/src/Transpiler.ts
@@ -2135,8 +2135,9 @@ export abstract class LuaTranspiler {
         }
         result += this.indent + `${className}.__index = ${className}\n`;
         if (extendsType) {
-            const baseName = extendsType.symbol.escapedName;
-            result += this.indent + `${className}.__base = ${baseName}\n`;
+          const extendedTypeNode = tsHelper.getExtendedTypeNode(node, this.checker);
+          const baseName = this.transpileNode(extendedTypeNode.expression);
+          result += this.indent + `${className}.__base = ${baseName}\n`;
         }
         result += this.indent + `function ${className}.new(construct, ...)\n`;
         result += this.indent + `    local self = setmetatable({}, ${className})\n`;

--- a/test/unit/class.spec.ts
+++ b/test/unit/class.spec.ts
@@ -333,6 +333,31 @@ export class ClassTests {
         Expect(result).toBe(10);
     }
 
+    @Test("renamedClassExtends")
+    public renamedClassExtends(): void {
+        // Transpile
+        const lua = util.transpileString(
+            `namespace Classes{
+              export class Base{
+                value:number;
+                constructor(){ this.value = 3; }
+              }
+            }
+            const A = Classes.Base;
+            class B extends A{
+              constructor(){ super(); }
+            };
+            const b = new B();
+            return b.value;`
+        );
+
+        // Execute
+        const result = util.executeLua(lua);
+
+        // Assert
+        Expect(result).toBe(3);
+    }
+
     @Test("ClassMethodCall")
     public classMethodCall(): void {
         // Transpile


### PR DESCRIPTION
This fixes errors when extending from a renamed class.
The following example will now transpile and run correctly.

```
// base.ts
export class Type{ 
  constructor(){}
};
```

```
// main.ts
import { Type as TypeBase } from "./base";
class Type extends TypeBase{
  constructor(){ super(); }
};
const x = new Type();
```