### PR TITLE
Fix lua identifier

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -514,7 +514,8 @@ export class TSHelper {
     }
 
     public static isValidLuaIdentifier(str: string): boolean {
-        return str.match(/[a-zA-Z_][a-zA-Z0-9_]*/) !== null;
+        const match = str.match(/[a-zA-Z_][a-zA-Z0-9_]*/);
+        return match && match[0] === str;
     }
 
     public static isFalsible(type: ts.Type, strictNullChecks: boolean): boolean {

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -803,4 +803,14 @@ export class AssignmentTests {
             "Unsupported assignment of mixed function/method overload. "
             + "Overloads should either be all functions or all methods, but not both.");
     }
+
+    @Test("String table access")
+    public stringTableAccess(assignType: string): void {
+        const code = `const dict : {[key:string]:any} = {};
+                      dict["a b"] = 3;
+                      return dict["a b"];`;
+        const result = util.transpileAndExecute(code);
+        Expect(result).toBe(3);
+    }
+
 }


### PR DESCRIPTION
Ensures that `isValidLuaIdentifier` actually checks the full string.
Before we could get stuff like `dict["a b"] = 3` -> `dict.a b = 3 `.
