### PR TITLE
add export to super call class identifier

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2348,7 +2348,7 @@ export class LuaTransformer {
 
             return tstl.createCallExpression(
                 tstl.createTableIndexExpression(
-                    tstl.createTableIndexExpression(classIdentifier, baseIdentifier),
+                    tstl.createTableIndexExpression(this.addExportToIdentifier(classIdentifier), baseIdentifier),
                     constructorIdentifier
                 ),
                 parameters


### PR DESCRIPTION
Allows calling constructors on exported base classes. As tests with export are currently unsupported, here is some theoretical test code.

```
export class Base{
  value: number;
  constructor(){ this.value = 7; }
}

export class Derived extends Base{
  constructor(){ super(); }
}

const a = new Derived();
Expect(a.value).toBe(7)
```