### PR TITLE
named import prefix

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -177,10 +177,6 @@ export class LuaTransformer {
         return tstl.createDoStatement(this.transformStatements(block.statements), undefined, block);
     }
 
-    public tstlIdentifier(name: string): string {
-        return "__TSTL_" + name;
-    }
-
     public transformImportDeclaration(statement: ts.ImportDeclaration): StatementVisitResult {
         if (!statement.importClause || !statement.importClause.namedBindings) {
             throw TSTLErrors.DefaultImportsNotSupported(statement);
@@ -207,9 +203,10 @@ export class LuaTransformer {
                 return undefined;
             }
 
-            const importUniqueName = tstl.createIdentifier(this.tstlIdentifier(path.basename((importPath))));
+            const tstlIdentifier = (name: string) => "__TSTL_" + name;
+            const importUniqueName = tstl.createIdentifier(tstlIdentifier(path.basename((importPath))));
             const requireStatement = tstl.createVariableDeclarationStatement(
-                tstl.createIdentifier(this.tstlIdentifier(path.basename((importPath)))),
+                tstl.createIdentifier(tstlIdentifier(path.basename((importPath)))),
                 requireCall,
                 undefined,
                 statement

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -177,6 +177,10 @@ export class LuaTransformer {
         return tstl.createDoStatement(this.transformStatements(block.statements), undefined, block);
     }
 
+    public tstlIdentifier(name: string): string {
+        return "__TSTL_" + name;
+    }
+
     public transformImportDeclaration(statement: ts.ImportDeclaration): StatementVisitResult {
         if (!statement.importClause || !statement.importClause.namedBindings) {
             throw TSTLErrors.DefaultImportsNotSupported(statement);
@@ -203,9 +207,13 @@ export class LuaTransformer {
                 return undefined;
             }
 
-            const importUniqueName = tstl.createIdentifier(path.basename((importPath)));
+            const importUniqueName = tstl.createIdentifier(this.tstlIdentifier(path.basename((importPath))));
             const requireStatement = tstl.createVariableDeclarationStatement(
-                tstl.createIdentifier(path.basename(importPath)), requireCall, undefined, statement);
+                tstl.createIdentifier(this.tstlIdentifier(path.basename((importPath)))),
+                requireCall,
+                undefined,
+                statement
+            );
             result.push(requireStatement);
 
             filteredElements.forEach(importSpecifier => {

--- a/test/translation/lua/modulesImportNamed.lua
+++ b/test/translation/lua/modulesImportNamed.lua
@@ -1,2 +1,2 @@
-local test = require("test");
-local TestClass = test.TestClass;
+local __TSTL_test = require("test");
+local TestClass = __TSTL_test.TestClass;

--- a/test/translation/lua/modulesImportRenamed.lua
+++ b/test/translation/lua/modulesImportRenamed.lua
@@ -1,2 +1,2 @@
-local test = require("test");
-local RenamedClass = test.TestClass;
+local __TSTL_test = require("test");
+local RenamedClass = __TSTL_test.TestClass;


### PR DESCRIPTION
Prevent global shadowing by adding an tstl prefix to imported modules when using named imports.
Example below.

```
import {printer} from "./print";
declare let print;
print("test"); // errors as print has been overridden by named import 
```