### PR TITLE
ObjectBindingPatterns Implementation

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -803,6 +803,10 @@ export class LuaTransformer {
                     propertyAccessStack.push(propertyName);
                     yield* this.transformBindingPattern(element.name, table, propertyAccessStack);
                 } else {
+                    // Disallow ellipsis destructure
+                    if (element.dotDotDotToken) {
+                        throw TSTLErrors.ForbiddenEllipsisDestruction(element);
+                    }
                     // Build the path to the table
                     let tableExpression: tstl.Expression = table;
                     propertyAccessStack.forEach(property => {

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -722,6 +722,7 @@ export class LuaTransformer {
                 dotsLiteral = tstl.createDotsLiteral();
             }
         }
+
         return [paramNames, dotsLiteral, restParamName];
     }
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1066,13 +1066,13 @@ export class LuaTransformer {
         } else if (ts.isObjectBindingPattern(statement.name)) {
             const statements = [];
             let table: tstl.Identifier;
-            if (ts.isObjectLiteralExpression(statement.initializer)) {
-                // If destructuring a literal table, declare the table first
-                table = tstl.createIdentifier("_");
+            if (ts.isIdentifier(statement.initializer)) {
+                table = this.transformIdentifier(statement.initializer);
+            } else {
+                // Contain the expression in a temporary variable
+                table = tstl.createIdentifier("____");
                 statements.push(tstl.createVariableDeclarationStatement(
                     table, this.transformExpression(statement.initializer)));
-            } else if (ts.isIdentifier(statement.initializer)) {
-                table = this.transformIdentifier(statement.initializer);
             }
             statements.push(...this.transformObjectBindingPattern(statement.name, table));
             return statements;

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -41,7 +41,6 @@ export class LuaTransformer {
 
     private scopeStack: Scope[];
     private genVarCounter: number;
-    private parameterIndex: number;
 
     private luaLibFeatureSet: Set<LuaLibFeature>;
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -808,11 +808,13 @@ export class LuaTransformer {
                     tableExpression = tstl.createTableIndexExpression(tableExpression, propertyName);
                 });
                 const propertyNameString = tstl.createStringLiteral(propertyName.text);
-                let tableAccessExpression: tstl.Expression = tstl.createTableIndexExpression(tableExpression, propertyNameString);
+                let tableAccessExpression: tstl.Expression =
+                    tstl.createTableIndexExpression(tableExpression, propertyNameString);
                 if (element.initializer) {
-                    tableAccessExpression = tstl.createBinaryExpression(tableAccessExpression, this.transformExpression(element.initializer), tstl.SyntaxKind.OrOperator);
+                    tableAccessExpression = tstl.createBinaryExpression(tableAccessExpression,
+                        this.transformExpression(element.initializer), tstl.SyntaxKind.OrOperator);
                 }
-                yield tstl.createVariableDeclarationStatement(name, tableAccessExpression);
+                yield* this.createLocalOrExportedOrGlobalDeclaration(name, tableAccessExpression);
             }
         }
         propertyAccessStack.pop();

--- a/test/unit/bindingpatterns.spec.ts
+++ b/test/unit/bindingpatterns.spec.ts
@@ -4,9 +4,7 @@ import * as util from "../src/util";
 
 const testCases = [
     ["{x}", "{x: true}", "x"],
-    ["{x = true}", "{}", "x"],
     ["{x, y}", "{x: false, y: true}", "y"],
-    ["{x, y = true}", "{x: false}", "y"],
     ["{x: foo, y}", "{x: true, y: false}", "foo"],
     ["{x: foo, y: bar}", "{x: false, y: true}", "bar"],
     ["{x: {x, y}, z}", "{x: {x: true, y: false}, z: false}", "x"],
@@ -14,11 +12,17 @@ const testCases = [
     ["{x: {x, y}, z}", "{x: {x: false, y: false}, z: true}", "z"],
 ];
 
+const testCasesDefault = [
+    ["{x = true}", "{}", "x"],
+    ["{x, y = true}", "{x: false}", "y"],
+];
+
 export class BindingPatternTests {
 
     @TestCase("{x, y}, z", "{x: false, y: false}, true", "z")
     @TestCase("{x, y}, {z}", "{x: false, y: false}, {z: true}", "z")
     @TestCases(testCases)
+    @TestCases(testCasesDefault)
     @Test("Object bindings in functions")
     public testObjectBindingPatternParameters(
         bindingString: string,
@@ -35,6 +39,7 @@ export class BindingPatternTests {
     }
 
     @TestCases(testCases)
+    @TestCases(testCasesDefault)
     public testObjectBindingPatternDeclarations(
         bindingString: string,
         objectString: string,
@@ -46,4 +51,22 @@ export class BindingPatternTests {
         `);
         Expect(result).toBe(true);
     }
+
+    @TestCases(testCases)
+    @Test("Object bindings with call expressions")
+    public testObjectBindingCallExpressions(
+        bindingString: string,
+        objectString: string,
+        returnVariable: string
+    ): void {
+        const result = util.transpileAndExecute(`
+            function call() {
+                return ${objectString};
+            }
+            let ${bindingString} = call();
+            return ${returnVariable};
+        `);
+        Expect(result).toBe(true);
+    }
+
 }

--- a/test/unit/bindingpatterns.spec.ts
+++ b/test/unit/bindingpatterns.spec.ts
@@ -1,0 +1,42 @@
+import { Expect, Test, TestCase, FocusTest, TestCases } from "alsatian";
+import { TranspileError } from "../../src/TranspileError";
+
+import * as util from "../src/util";
+
+const testCases = [
+    ["{x}", "{x: true}", "x"],
+    ["{x = true}", "{}", "x"],
+    ["{x, y}", "{x: false, y: true}", "y"],
+    ["{x, y = true}", "{x: false}", "y"],
+    ["{x: foo, y}", "{x: true, y: false}", "foo"],
+    ["{x: foo, y: bar}", "{x: false, y: true}", "bar"],
+    ["{x: {x, y}, z}", "{x: {x: true, y: false}, z: false}", "x"],
+    ["{x: {x, y}, z}", "{x: {x: false, y: true}, z: false}", "y"],
+    ["{x: {x, y}, z}", "{x: {x: false, y: false}, z: true}", "z"],
+];
+
+export class BindingPatternTests {
+
+    @TestCase("{x, y}, z", "{x: false, y: false}, true", "z")
+    @TestCase("{x, y}, {z}", "{x: false, y: false}, {z: true}", "z")
+    @TestCases(testCases)
+    @Test("Object bindings in functions")
+    public testObjectBindingPatternParameters(bindingString: string, objectString: string, returnVariable: string): void {
+        const result = util.transpileAndExecute(`
+            function test(${bindingString}) {
+                return ${returnVariable};
+            }
+            return test(${objectString});
+        `);
+        Expect(result).toBe(true);
+    }
+
+    @TestCases(testCases)
+    public testObjectBindingPatternDeclarations(bindingString: string, objectString: string, returnVariable: string) {
+        const result = util.transpileAndExecute(`
+            let ${bindingString} = ${objectString};
+            return ${returnVariable};
+        `);
+        Expect(result).toBe(true);
+    }
+}

--- a/test/unit/bindingpatterns.spec.ts
+++ b/test/unit/bindingpatterns.spec.ts
@@ -1,5 +1,4 @@
 import { Expect, Test, TestCase, FocusTest, TestCases } from "alsatian";
-import { TranspileError } from "../../src/TranspileError";
 
 import * as util from "../src/util";
 
@@ -21,7 +20,11 @@ export class BindingPatternTests {
     @TestCase("{x, y}, {z}", "{x: false, y: false}, {z: true}", "z")
     @TestCases(testCases)
     @Test("Object bindings in functions")
-    public testObjectBindingPatternParameters(bindingString: string, objectString: string, returnVariable: string): void {
+    public testObjectBindingPatternParameters(
+        bindingString: string,
+        objectString: string,
+        returnVariable: string
+    ): void {
         const result = util.transpileAndExecute(`
             function test(${bindingString}) {
                 return ${returnVariable};
@@ -32,7 +35,11 @@ export class BindingPatternTests {
     }
 
     @TestCases(testCases)
-    public testObjectBindingPatternDeclarations(bindingString: string, objectString: string, returnVariable: string) {
+    public testObjectBindingPatternDeclarations(
+        bindingString: string,
+        objectString: string,
+        returnVariable: string
+    ): void {
         const result = util.transpileAndExecute(`
             let ${bindingString} = ${objectString};
             return ${returnVariable};

--- a/test/unit/bindingpatterns.spec.ts
+++ b/test/unit/bindingpatterns.spec.ts
@@ -4,6 +4,11 @@ import * as util from "../src/util";
 
 const testCases = [
     ["{x}", "{x: true}", "x"],
+    ["[x, y]", "[false, true]", "y"],
+    ["{x: [y, z]}", "{x: [false, true]}", "z"],
+    ["{x: [, z]}", "{x: [false, true]}", "z"],
+    ["{x: [{y}]}", "{x: [{y: true}]}", "y"],
+    ["[[y, z]]", "[[false, true]]", "z"],
     ["{x, y}", "{x: false, y: true}", "y"],
     ["{x: foo, y}", "{x: true, y: false}", "foo"],
     ["{x: foo, y: bar}", "{x: false, y: true}", "bar"],
@@ -24,7 +29,7 @@ export class BindingPatternTests {
     @TestCases(testCases)
     @TestCases(testCasesDefault)
     @Test("Object bindings in functions")
-    public testObjectBindingPatternParameters(
+    public tesBindingPatternParameters(
         bindingString: string,
         objectString: string,
         returnVariable: string
@@ -40,7 +45,7 @@ export class BindingPatternTests {
 
     @TestCases(testCases)
     @TestCases(testCasesDefault)
-    public testObjectBindingPatternDeclarations(
+    public testBindingPatternDeclarations(
         bindingString: string,
         objectString: string,
         returnVariable: string
@@ -54,7 +59,7 @@ export class BindingPatternTests {
 
     @TestCases(testCases)
     @Test("Object bindings with call expressions")
-    public testObjectBindingCallExpressions(
+    public testBindingPatternCallExpressions(
         bindingString: string,
         objectString: string,
         returnVariable: string

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -507,16 +507,6 @@ export class ExpressionTests {
             .toThrowError(TranspileError, "Unsupported property on math: unknownProperty");
     }
 
-    @Test("Unsupported variable declaration type error")
-    public unsupportedVariableDeclarationType(): void {
-        const transformer = util.makeTestTransformer();
-
-        const mockNode: any = {name: ts.createLiteral(false)};
-
-        Expect(() => transformer.transformVariableDeclaration(mockNode as ts.VariableDeclaration))
-            .toThrowError(TranspileError, "Unsupported variable declaration kind: FalseKeyword");
-    }
-
     @Test("Unsupported object literal element error")
     public unsupportedObjectLiteralElementError(): void {
         const transformer = util.makeTestTransformer();


### PR DESCRIPTION
I've implemented Object Binding Patterns.

They can be used in methods, functions and declarations.

```ts
function test({x, y}) {
    print(x, y);
}
let {x, y} = {x: 0, y: 1};

test({x: 0, y: 1});     // Prints 0, 1
print(x, y);            // Prints 0, 1
```

They can have default values / initializers.

```ts
let {x = 5, y} = {y: 5};
print(x, y);            // Prints 5, 5
```

They can be nested.

```ts
let {x: {x, y}, z} = {x: {x: 0, y: 1}, z: 2};
print(x, y, z);         // Prints 0, 1, 2
```

They can have aliases.

```ts
let {x: foo, y: bar} = {x: 0, y: 1};
print(foo, bar);        // Prints 0, 1
```

They can also be exported.

```ts
export let {x, y} = {x: 0, y: 1};
```

I removed the throw from `transformVariableDeclaration` since TypeScript knows that all possible cases have been covered so it thinks the code is unreachable. It can be reached forcefully as evidenced in one specific test case. I removed this since TypeScript will never allow you to use a `false` keyword for a variable identifier.