### PR TITLE
Fix for export detection of shadowed names

### DIFF
--- a/test/unit/functions.spec.ts
+++ b/test/unit/functions.spec.ts
@@ -1,4 +1,4 @@
-import { Expect, Test, TestCase, FocusTest } from "alsatian";
+import { Expect, Test, TestCase } from "alsatian";
 
 import * as ts from "typescript";
 import * as util from "../src/util";
@@ -387,5 +387,16 @@ export class FunctionTests {
         `;
         const result = util.transpileAndExecute(code);
         Expect(result).toBe("foobar");
+    }
+
+    @Test("Function local overriding export")
+    public functionLocalOverridingExport(): void {
+        const code =
+            `export const foo = 5;
+            function bar(foo: number) {
+                return foo;
+            }
+            export const result = bar(7);`;
+        Expect(util.transpileExecuteAndReturnExport(code, "result")).toBe(7);
     }
 }


### PR DESCRIPTION
fixes #385

Symbols are now used directly when determining if identifiers should be exported instead of just using their string name.