### PR TITLE
Fixed enums with identifier values not being supported.

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1011,13 +1011,13 @@ export class LuaTransformer {
                 if (ts.isNumericLiteral(member.initializer))
                 {
                     numericValue = Number(member.initializer.text);
-                    valueExpression = tstl.createNumericLiteral(numericValue);
+                    valueExpression = this.transformNumericLiteral(member.initializer);
                     numericValue++;
                 }
                 else if (ts.isStringLiteral(member.initializer))
                 {
                     hasStringInitializers = true;
-                    valueExpression = tstl.createStringLiteral(member.initializer.text);
+                    valueExpression = this.transformStringLiteral(member.initializer);
                 }
                 else
                 {

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -625,4 +625,21 @@ export class TSHelper {
         const firstDeclaration = this.getFirstDeclaration(symbol);
         return firstDeclaration === node;
     }
+
+    public static isEnumMember(enumDeclaration: ts.EnumDeclaration, value: ts.Expression): [boolean, ts.PropertyName] {
+        if (ts.isIdentifier(value)) {
+            const enumMember = enumDeclaration.members.find(m => ts.isIdentifier(m.name) && m.name.text === value.text);
+            if (enumMember !== undefined) {
+                if (enumMember.initializer && ts.isIdentifier(enumMember.initializer)) {
+                    return this.isEnumMember(enumDeclaration, enumMember.initializer);
+                } else {
+                    return [true, enumMember.name];
+                }
+            } else {
+                return [false, undefined];
+            }
+        } else {
+            return [false, undefined];
+        }
+    }
 }

--- a/src/TSTLErrors.ts
+++ b/src/TSTLErrors.ts
@@ -4,6 +4,11 @@ import {TranspileError} from "./TranspileError";
 import {TSHelper as tsHelper} from "./TSHelper";
 
 export class TSTLErrors {
+    public static CouldNotFindEnumMember =
+        (enumDeclaration: ts.EnumDeclaration, enumMember: string, node: ts.Node) => new TranspileError(
+            `Could not find ${enumMember} in ${enumDeclaration.name.text}`, node
+        );
+
     public static DefaultImportsNotSupported = (node: ts.Node) =>
         new TranspileError(`Default Imports are not supported, please use named imports instead!`, node);
 

--- a/test/translation/lua/enum.lua
+++ b/test/translation/lua/enum.lua
@@ -1,4 +1,7 @@
 TestEnum = {};
 TestEnum.val1 = 0;
+TestEnum[0] = "val1";
 TestEnum.val2 = 2;
+TestEnum[2] = "val2";
 TestEnum.val3 = 3;
+TestEnum[3] = "val3";

--- a/test/translation/lua/enumHeterogeneous.lua
+++ b/test/translation/lua/enumHeterogeneous.lua
@@ -1,4 +1,7 @@
 TestEnum = {};
 TestEnum.val1 = 0;
+TestEnum[0] = "val1";
 TestEnum.val2 = 3;
+TestEnum[3] = "val2";
 TestEnum.val3 = "baz";
+TestEnum.baz = "val3";

--- a/test/translation/lua/enumString.lua
+++ b/test/translation/lua/enumString.lua
@@ -1,4 +1,7 @@
 TestEnum = {};
 TestEnum.val1 = "foo";
+TestEnum.foo = "val1";
 TestEnum.val2 = "bar";
+TestEnum.bar = "val2";
 TestEnum.val3 = "baz";
+TestEnum.baz = "val3";

--- a/test/translation/lua/modulesNamespaceExportEnum.lua
+++ b/test/translation/lua/modulesNamespaceExportEnum.lua
@@ -4,6 +4,8 @@ local test = exports.test;
 do
     test.TestEnum = {};
     test.TestEnum.foo = "foo";
+    test.TestEnum.foo = "foo";
+    test.TestEnum.bar = "bar";
     test.TestEnum.bar = "bar";
 end
 return exports;

--- a/test/unit/enum.spec.ts
+++ b/test/unit/enum.spec.ts
@@ -26,10 +26,10 @@ export class EnumTests {
                 MEMBER_TWO = "test2"
             }
 
-            const valueOne = TestEnum.MEMBER_ONE;
+            const valueOne = TestEnum.MEMBER_TWO;
         `;
 
-        Expect(util.transpileString(testCode)).toBe(`local valueOne = "test";`);
+        Expect(util.transpileString(testCode)).toBe(`local valueOne = "test2";`);
     }
 
     @Test("Const enum without initializer")
@@ -40,10 +40,10 @@ export class EnumTests {
                 MEMBER_TWO
             }
 
-            const valueOne = TestEnum.MEMBER_ONE;
+            const valueOne = TestEnum.MEMBER_TWO;
         `;
 
-        Expect(util.transpileString(testCode)).toBe(`local valueOne = 0;`);
+        Expect(util.transpileString(testCode)).toBe(`local valueOne = 1;`);
     }
 
     @Test("Const enum without initializer in some values")

--- a/test/unit/enum.spec.ts
+++ b/test/unit/enum.spec.ts
@@ -76,20 +76,6 @@ export class EnumTests {
                         + "member values, or specify values (of the same type) for all members.");
     }
 
-    @Test("Unsuported enum")
-    public unsuportedEnum(): void {
-        // Transpile & Assert
-        Expect(() => {
-            const lua = util.transpileString(
-                `enum TestEnum {
-                    val1 = [],
-                    val2 = "ok",
-                    val3 = "bye"
-                }`
-            );
-        }).toThrowError(TranspileError, "Only numeric or string initializers allowed for enums.");
-    }
-
     @Test("String literal name in enum")
     public stringLiteralNameEnum(): void {
         const code = `enum TestEnum {
@@ -98,5 +84,78 @@ export class EnumTests {
             return TestEnum["name"];`;
         const result = util.transpileAndExecute(code);
         Expect(result).toBe("foo");
+    }
+
+    @Test("Enum identifier value internal")
+    public enumIdentifierValueInternal(): void {
+        const result = util.transpileAndExecute(
+            `enum testEnum {
+                abc,
+                def,
+                ghi = def,
+                jkl,
+            }
+            return \`\${testEnum.abc},\${testEnum.def},\${testEnum.ghi},\${testEnum.jkl}\`;`
+        );
+
+        Expect(result).toBe("0,1,1,2");
+    }
+
+    @Test("Enum identifier value internal recursive")
+    public enumIdentifierValueInternalRecursive(): void {
+        const result = util.transpileAndExecute(
+            `enum testEnum {
+                abc,
+                def,
+                ghi = def,
+                jkl = ghi,
+            }
+            return \`\${testEnum.abc},\${testEnum.def},\${testEnum.ghi},\${testEnum.jkl}\`;`
+        );
+
+        Expect(result).toBe("0,1,1,1");
+    }
+
+    @Test("Enum identifier value external")
+    public enumIdentifierValueExternal(): void {
+        const result = util.transpileAndExecute(
+            `const ext = 6;
+            enum testEnum {
+                abc,
+                def,
+                ghi = ext,
+            }
+            return \`\${testEnum.abc},\${testEnum.def},\${testEnum.ghi}\`;`
+        );
+
+        Expect(result).toBe("0,1,6");
+    }
+
+    @Test("Enum reverse mapping")
+    public enumReverseMapping(): void {
+        const result = util.transpileAndExecute(
+            `enum testEnum {
+                abc,
+                def,
+                ghi
+            }
+            return testEnum[testEnum.abc] + testEnum[testEnum.ghi]`
+        );
+
+        Expect(result).toBe("abcghi");
+    }
+
+    @Test("Const enum index")
+    public constEnumIndex(): void {
+        const result = util.transpileAndExecute(
+            `const enum testEnum {
+                abc,
+                def,
+                ghi
+            }
+            return testEnum["def"];`
+        );
+
+        Expect(result).toBe(1);
     }
 }

--- a/test/unit/enum.spec.ts
+++ b/test/unit/enum.spec.ts
@@ -158,4 +158,34 @@ export class EnumTests {
 
         Expect(result).toBe(1);
     }
+
+    @Test("Const enum index identifier value")
+    public constEnumIndexIdnetifierValue(): void {
+        const result = util.transpileAndExecute(
+            `const enum testEnum {
+                abc,
+                def = 4,
+                ghi,
+                jkl = ghi
+            }
+            return testEnum["jkl"];`
+        );
+
+        Expect(result).toBe(5);
+    }
+
+    @Test("Const enum index identifier chain")
+    public constEnumIndexIdnetifierChain(): void {
+        const result = util.transpileAndExecute(
+            `const enum testEnum {
+                abc = 3,
+                def,
+                ghi = def,
+                jkl = ghi,
+            }
+            return testEnum["ghi"];`
+        );
+
+        Expect(result).toBe(4);
+    }
 }


### PR DESCRIPTION
Added reverse mapping for enums, allowing:
```ts
const myEnum {
    abc,
    def,
}
const x = myEnum.def; // x = 1
const y = myEnum[x]; // y = "def"
```

Also added support for `constEnum["enumMemberName"]` and refactored the const enum handling stuff a little.

Fixes #378 and closes #318 