### PR TITLE
Custom symbols

### DIFF
--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -33,6 +33,7 @@ export enum LuaLibFeature {
     StringSplit = "StringSplit",
     StringConcat = "StringConcat",
     Symbol = "Symbol",
+    SymbolRegistry = "SymbolRegistry",
 }
 
 const luaLibDependencies: {[lib in LuaLibFeature]?: LuaLibFeature[]} = {
@@ -41,6 +42,7 @@ const luaLibDependencies: {[lib in LuaLibFeature]?: LuaLibFeature[]} = {
     Set: [LuaLibFeature.InstanceOf, LuaLibFeature.Iterator, LuaLibFeature.Symbol],
     WeakMap: [LuaLibFeature.InstanceOf, LuaLibFeature.Iterator, LuaLibFeature.Symbol],
     WeakSet: [LuaLibFeature.InstanceOf, LuaLibFeature.Iterator, LuaLibFeature.Symbol],
+    SymbolRegistry: [LuaLibFeature.Symbol],
 };
 
 export class LuaLib {

--- a/src/lualib/Symbol.ts
+++ b/src/lualib/Symbol.ts
@@ -1,3 +1,19 @@
+declare function setmetatable<T extends object>(obj: T, metatable: any): T;
+
+const symbolMetatable = {
+    __tostring(): string {
+        if (this.description === undefined) {
+            return 'Symbol()';
+        } else {
+            return 'Symbol(' + this.description + ')';
+        }
+    },
+};
+
+function __TS__Symbol(description?: string | number): symbol {
+    return setmetatable({ description }, symbolMetatable) as any;
+}
+
 Symbol = {
-    iterator: {},
+    iterator: __TS__Symbol('Symbol.iterator'),
 } as any;

--- a/src/lualib/Symbol.ts
+++ b/src/lualib/Symbol.ts
@@ -1,6 +1,7 @@
 declare function setmetatable<T extends object>(obj: T, metatable: any): T;
 
-const symbolMetatable = {
+// tslint:disable-next-line: variable-name
+const ____symbolMetatable = {
     __tostring(): string {
         if (this.description === undefined) {
             return 'Symbol()';
@@ -11,7 +12,7 @@ const symbolMetatable = {
 };
 
 function __TS__Symbol(description?: string | number): symbol {
-    return setmetatable({ description }, symbolMetatable) as any;
+    return setmetatable({ description }, ____symbolMetatable) as any;
 }
 
 Symbol = {

--- a/src/lualib/SymbolRegistry.ts
+++ b/src/lualib/SymbolRegistry.ts
@@ -1,0 +1,15 @@
+const symbolRegistry: Record<string, symbol> = {};
+
+function __TS__SymbolRegistryFor(key: string): symbol {
+    if (!symbolRegistry[key])  {
+        symbolRegistry[key] = __TS__Symbol(key);
+    }
+
+    return symbolRegistry[key];
+}
+
+function __TS__SymbolRegistryKeyFor(sym: symbol): string {
+    for (const key in symbolRegistry) {
+        if (symbolRegistry[key] === sym) return key;
+    }
+}

--- a/src/lualib/SymbolRegistry.ts
+++ b/src/lualib/SymbolRegistry.ts
@@ -1,15 +1,16 @@
-const symbolRegistry: Record<string, symbol> = {};
+// tslint:disable-next-line: variable-name
+const ____symbolRegistry: Record<string, symbol> = {};
 
 function __TS__SymbolRegistryFor(key: string): symbol {
-    if (!symbolRegistry[key])  {
-        symbolRegistry[key] = __TS__Symbol(key);
+    if (!____symbolRegistry[key])  {
+        ____symbolRegistry[key] = __TS__Symbol(key);
     }
 
-    return symbolRegistry[key];
+    return ____symbolRegistry[key];
 }
 
 function __TS__SymbolRegistryKeyFor(sym: symbol): string {
-    for (const key in symbolRegistry) {
-        if (symbolRegistry[key] === sym) return key;
+    for (const key in ____symbolRegistry) {
+        if (____symbolRegistry[key] === sym) return key;
     }
 }

--- a/test/unit/lualib/symbol.spec.ts
+++ b/test/unit/lualib/symbol.spec.ts
@@ -34,6 +34,16 @@ export class SymbolTests {
         Expect(result).toBe(description);
     }
 
+    @Test("symbol uniqueness")
+    public symbolUniqueness(): void
+    {
+        const result = util.transpileAndExecute(`
+            return Symbol("a") === Symbol("a");
+        `);
+
+        Expect(result).toBe(false);
+    }
+
     @Test("Symbol.for")
     public symbolFor(): void
     {
@@ -44,8 +54,8 @@ export class SymbolTests {
         Expect(result).toBe("name");
     }
 
-    @Test("Symbol.for reference")
-    public symbolForReference(): void
+    @Test("Symbol.for non-uniqueness")
+    public symbolForNonUniqueness(): void
     {
         const result = util.transpileAndExecute(`
             return Symbol.for("a") === Symbol.for("a");

--- a/test/unit/lualib/symbol.spec.ts
+++ b/test/unit/lualib/symbol.spec.ts
@@ -1,0 +1,79 @@
+import { Expect, Test, TestCase } from "alsatian";
+import * as util from "../../src/util";
+import { CompilerOptions, LuaLibImportKind } from '../../../src/CompilerOptions';
+
+export class SymbolTests {
+    private compilerOptions: CompilerOptions = {
+        lib: ["esnext"],
+        luaLibImport: LuaLibImportKind.Require,
+    };
+
+    @Test("symbol.toString()")
+    @TestCase()
+    @TestCase(1)
+    @TestCase("name")
+    public symbolToString(description?: string | number): void
+    {
+        const result = util.transpileAndExecute(`
+            return Symbol(${JSON.stringify(description)}).toString();
+        `, this.compilerOptions);
+
+        Expect(result).toBe(`Symbol(${description || ''})`);
+    }
+
+    @Test("symbol.description")
+    @TestCase()
+    @TestCase(1)
+    @TestCase("name")
+    public symbolDescription(description?: string | number): void
+    {
+        const result = util.transpileAndExecute(`
+            return Symbol(${JSON.stringify(description)}).description;
+        `, this.compilerOptions);
+
+        Expect(result).toBe(description);
+    }
+
+    @Test("Symbol.for")
+    public symbolFor(): void
+    {
+        const result = util.transpileAndExecute(`
+            return Symbol.for("name").description;
+        `, this.compilerOptions);
+
+        Expect(result).toBe("name");
+    }
+
+    @Test("Symbol.for reference")
+    public symbolForReference(): void
+    {
+        const result = util.transpileAndExecute(`
+            return Symbol.for("a") === Symbol.for("a");
+        `);
+
+        Expect(result).toBe(true);
+    }
+
+    @Test("Symbol.keyFor")
+    public symbolKeyFor(): void
+    {
+        const result = util.transpileAndExecute(`
+            const sym = Symbol.for("a");
+            Symbol.for("b");
+            return Symbol.keyFor(sym);
+        `);
+
+        Expect(result).toBe("a");
+    }
+
+    @Test("Symbol.keyFor empty")
+    public symbolKeyForEmpty(): void
+    {
+        const result = util.transpileAndExecute(`
+            Symbol.for("a");
+            return Symbol.keyFor(Symbol());
+        `);
+
+        Expect(result).toBe(undefined);
+    }
+}


### PR DESCRIPTION
`typeof Symbol()` still returns `object`, since I don't see much need in this right now.

Uses the same code as #402 to use exnext `Symbol.description` type in tests.
