### PR TITLE
For Scope Fix

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1568,7 +1568,7 @@ export class LuaTransformer {
         );
     }
 
-    public transformForStatement(statement: ts.ForStatement): tstl.Statement[] {
+    public transformForStatement(statement: ts.ForStatement): tstl.DoStatement {
         const result: tstl.Statement[] = [];
 
         if (statement.initializer) {
@@ -1596,7 +1596,7 @@ export class LuaTransformer {
         // while (condition) do ... end
         result.push(tstl.createWhileStatement(tstl.createBlock(body), condition));
 
-        return result;
+        return tstl.createDoStatement(result, statement);
     }
 
     public transformForOfInitializer(initializer: ts.ForInitializer, expression: tstl.Expression): tstl.Statement {

--- a/test/translation/lua/continue.lua
+++ b/test/translation/lua/continue.lua
@@ -1,10 +1,12 @@
-local i = 0;
-while i < 10 do
-    do
-        if i < 5 then
-            goto __continue1;
+do
+    local i = 0;
+    while i < 10 do
+        do
+            if i < 5 then
+                goto __continue1;
+            end
         end
+        ::__continue1::
+        i = i + 1;
     end
-    ::__continue1::
-    i = i + 1;
 end

--- a/test/translation/lua/continueConcurrent.lua
+++ b/test/translation/lua/continueConcurrent.lua
@@ -1,13 +1,15 @@
-local i = 0;
-while i < 10 do
-    do
-        if i < 5 then
-            goto __continue1;
+do
+    local i = 0;
+    while i < 10 do
+        do
+            if i < 5 then
+                goto __continue1;
+            end
+            if i == 7 then
+                goto __continue1;
+            end
         end
-        if i == 7 then
-            goto __continue1;
-        end
+        ::__continue1::
+        i = i + 1;
     end
-    ::__continue1::
-    i = i + 1;
 end

--- a/test/translation/lua/continueNested.lua
+++ b/test/translation/lua/continueNested.lua
@@ -1,20 +1,24 @@
-local i = 0;
-while i < 5 do
-    do
-        if (i % 2) == 0 then
-            goto __continue1;
-        end
-        local j = 0;
-        while j < 2 do
+do
+    local i = 0;
+    while i < 5 do
+        do
+            if (i % 2) == 0 then
+                goto __continue1;
+            end
             do
-                if j == 1 then
-                    goto __continue3;
+                local j = 0;
+                while j < 2 do
+                    do
+                        if j == 1 then
+                            goto __continue3;
+                        end
+                    end
+                    ::__continue3::
+                    j = j + 1;
                 end
             end
-            ::__continue3::
-            j = j + 1;
         end
+        ::__continue1::
+        i = i + 1;
     end
-    ::__continue1::
-    i = i + 1;
 end

--- a/test/translation/lua/continueNestedConcurrent.lua
+++ b/test/translation/lua/continueNestedConcurrent.lua
@@ -1,23 +1,27 @@
-local i = 0;
-while i < 5 do
-    do
-        if (i % 2) == 0 then
-            goto __continue1;
-        end
-        local j = 0;
-        while j < 2 do
+do
+    local i = 0;
+    while i < 5 do
+        do
+            if (i % 2) == 0 then
+                goto __continue1;
+            end
             do
-                if j == 1 then
-                    goto __continue3;
+                local j = 0;
+                while j < 2 do
+                    do
+                        if j == 1 then
+                            goto __continue3;
+                        end
+                    end
+                    ::__continue3::
+                    j = j + 1;
                 end
             end
-            ::__continue3::
-            j = j + 1;
+            if i == 4 then
+                goto __continue1;
+            end
         end
-        if i == 4 then
-            goto __continue1;
-        end
+        ::__continue1::
+        i = i + 1;
     end
-    ::__continue1::
-    i = i + 1;
 end

--- a/test/translation/lua/for.lua
+++ b/test/translation/lua/for.lua
@@ -1,7 +1,9 @@
-local i = 1;
-while i <= 100 do
-    do
+do
+    local i = 1;
+    while i <= 100 do
+        do
+        end
+        ::__continue1::
+        i = i + 1;
     end
-    ::__continue1::
-    i = i + 1;
 end

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -263,6 +263,15 @@ export class LuaLoopTests
         Expect(result).toBe(JSON.stringify(expected));
     }
 
+    @TestCase("for scope")
+    public forScope(): void {
+        const code =
+            `let i = 42;
+            for (let i = 0; i < 10; ++i) {}
+            return i;`;
+        Expect(util.transpileAndExecute(code)).toBe(42);
+    }
+
     @TestCase({ ["test1"]: 0, ["test2"]: 1, ["test3"]: 2 }, { ["test1"]: 1, ["test2"]: 2, ["test3"]: 3 })
     @Test("forin[Object]")
     public forinObject(inp: any, expected: any): void


### PR DESCRIPTION
There's a scoping issue with for loops:
```ts
let i = 42;
for (let i = 0; i < 10; ++i) {}
print(i); // Should print 42, but prints 10
```
This is now fixed by wrapping the produces statements in a do...end block.
