### PR TITLE
fix json imports

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3734,7 +3734,7 @@ export class LuaTransformer {
     }
 
     private pathToLuaRequirePath(filePath: string): string {
-        return filePath.replace(new RegExp("\\\\|\/", "g"), ".").replace(/\.json$/, '');
+        return filePath.replace(/\.json$/, '').replace(new RegExp("\\\\|\/", "g"), ".");
     }
 
     private shouldExportIdentifier(identifier: tstl.Identifier | tstl.Identifier[]): boolean {


### PR DESCRIPTION
This allows importing modules named `json` again. Example:
```
import {encode} from "./modules/json";
```