### PR TITLE
Fix derived get accessor

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -540,7 +540,7 @@ export class LuaTransformer {
             createClassPrototype(),
             tstl.createStringLiteral("__index")
         );
-        if (statement.members.some(ts.isGetAccessor)) {
+        if (tsHelper.hasGetAccessorInClassOrAncestor(statement, this.checker)) {
             // className.prototype.____getters = {}
             const classPrototypeGetters = tstl.createTableIndexExpression(
                 createClassPrototype(),

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -385,6 +385,18 @@ export class TSHelper {
         ) !== undefined;
     }
 
+    public static hasGetAccessorInClassOrAncestor(
+        classDeclaration: ts.ClassLikeDeclarationBase,
+        checker: ts.TypeChecker
+    ): boolean
+    {
+        return TSHelper.findInClassOrAncestor(
+            classDeclaration,
+            c => c.members.some(ts.isGetAccessor),
+            checker
+        ) !== undefined;
+    }
+
     public static getPropertyName(propertyName: ts.PropertyName): string | number | undefined {
         if (ts.isIdentifier(propertyName) || ts.isStringLiteral(propertyName) || ts.isNumericLiteral(propertyName)) {
             return propertyName.text;

--- a/test/unit/accessors.spec.ts
+++ b/test/unit/accessors.spec.ts
@@ -6,7 +6,9 @@ export class AccessorTests {
     public getAccessor(): void {
         const code =
             `class Foo {
-                get foo() { return "foo"; }
+                _foo;
+                get foo() { return this._foo; }
+                constructor(){ this._foo = "foo"; }
             }
             const f = new Foo();
             return f.foo;`;
@@ -17,7 +19,9 @@ export class AccessorTests {
     public getAccessorInBaseClass(): void {
         const code =
             `class Foo {
-                get foo() { return "foo"; }
+                _foo;
+                get foo() { return this._foo; }
+                constructor(){ this._foo = "foo"; }
             }
             class Bar extends Foo {}
             const b = new Bar();


### PR DESCRIPTION
Previously, inherited `get` accessors broke as the __index metamethod wasn't being assigned correctly to the derived class. Example:
```
class Base{
  _property;
  get property(){ return this._property; }
  constructor(){
    this._property = 42;
    assert(this.property == 42); // boom
  }
}

class Derived extends Base{
}

const t = new Derived();
```