### PR TITLE
fix json imports v2

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3815,9 +3815,8 @@ export class LuaTransformer {
         const absoluteImportPath = this.formatPathToLuaPath(this.getAbsoluteImportPath(relativePath));
         const absoluteRootDirPath = this.formatPathToLuaPath(rootDir);
         if (absoluteImportPath.includes(absoluteRootDirPath)) {
-            const relativePathToRoot = this.formatPathToLuaPath(
-                absoluteImportPath.replace(absoluteRootDirPath, "").slice(1));
-            return this.formatPathToLuaPath(relativePathToRoot);
+            const relativePathToRoot =  absoluteImportPath.replace(absoluteRootDirPath, "").slice(1);
+            return relativePathToRoot;
         } else {
             throw TSTLErrors.UnresolvableRequirePath(undefined,
                 `Cannot create require path. Module does not exist within --rootDir`,


### PR DESCRIPTION
This allows importing modules named `json` once more. Example:
```
import {encode} from "./modules/json";
```