### PR TITLE
Static get/set accessors

### DIFF
--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -16,6 +16,8 @@ export enum LuaLibFeature {
     ArraySlice = "ArraySlice",
     ArraySome = "ArraySome",
     ArraySplice = "ArraySplice",
+    ClassIndex = "ClassIndex",
+    ClassNewIndex = "ClassNewIndex",
     FunctionApply = "FunctionApply",
     FunctionBind = "FunctionBind",
     FunctionCall = "FunctionCall",

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -132,7 +132,7 @@ export class TSHelper {
     }
 
     public static isStatic(node: ts.Node): boolean {
-        return node.modifiers && node.modifiers.some(m => m.kind === ts.SyntaxKind.StaticKeyword);
+        return node.modifiers !== undefined && node.modifiers.some(m => m.kind === ts.SyntaxKind.StaticKeyword);
     }
 
     public static isStringType(type: ts.Type): boolean {
@@ -392,12 +392,13 @@ export class TSHelper {
 
     public static hasGetAccessorInClassOrAncestor(
         classDeclaration: ts.ClassLikeDeclarationBase,
+        isStatic: boolean,
         checker: ts.TypeChecker
     ): boolean
     {
         return TSHelper.findInClassOrAncestor(
             classDeclaration,
-            c => c.members.some(ts.isGetAccessor),
+            c => c.members.some(m => ts.isGetAccessor(m) && TSHelper.isStatic(m) === isStatic),
             checker
         ) !== undefined;
     }
@@ -422,7 +423,7 @@ export class TSHelper {
         checker: ts.TypeChecker
     ): element is ts.GetAccessorDeclaration
     {
-        if (!ts.isGetAccessor(element)) {
+        if (!ts.isGetAccessor(element) || TSHelper.isStatic(element)) {
             return false;
         }
 

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -131,6 +131,10 @@ export class TSHelper {
         return false;
     }
 
+    public static isStatic(node: ts.Node): boolean {
+        return node.modifiers && node.modifiers.some(m => m.kind === ts.SyntaxKind.StaticKeyword);
+    }
+
     public static isStringType(type: ts.Type): boolean {
         return (type.flags & ts.TypeFlags.String) !== 0 || (type.flags & ts.TypeFlags.StringLike) !== 0 ||
                (type.flags & ts.TypeFlags.StringLiteral) !== 0;
@@ -375,12 +379,13 @@ export class TSHelper {
 
     public static hasSetAccessorInClassOrAncestor(
         classDeclaration: ts.ClassLikeDeclarationBase,
+        isStatic: boolean,
         checker: ts.TypeChecker
     ): boolean
     {
         return TSHelper.findInClassOrAncestor(
             classDeclaration,
-            c => c.members.some(ts.isSetAccessor),
+            c => c.members.some(m => ts.isSetAccessor(m) && TSHelper.isStatic(m) === isStatic),
             checker
         ) !== undefined;
     }

--- a/src/lualib/ClassIndex.ts
+++ b/src/lualib/ClassIndex.ts
@@ -1,0 +1,28 @@
+interface LuaClass {
+    ____super?: LuaClass;
+    ____getters?: { [key: string]: (self: LuaClass) => any };
+}
+
+declare function rawget<T, K extends keyof T>(obj: T, key: K): T[K];
+
+function __TS__ClassIndex(classTable: LuaClass, key: keyof LuaClass): any {
+    while (true) {
+        const getters = rawget(classTable, "____getters");
+        if (getters) {
+            const getter = getters[key];
+            if (getter) {
+                return getter(classTable);
+            }
+        }
+
+        classTable = rawget(classTable, "____super");
+        if (!classTable) {
+            break;
+        }
+
+        const val = rawget(classTable, key);
+        if (val !== null) {
+            return val;
+        }
+    }
+}

--- a/src/lualib/ClassNewIndex.ts
+++ b/src/lualib/ClassNewIndex.ts
@@ -1,0 +1,26 @@
+interface LuaClass {
+    ____super?: LuaClass;
+    ____setters?: { [key: string]: (self: LuaClass, val: any) => void };
+}
+
+declare function rawget<T, K extends keyof T>(obj: T, key: K): T[K];
+declare function rawset<T, K extends keyof T>(obj: T, key: K, val: T[K]): void;
+
+function __TS__ClassNewIndex(classTable: LuaClass, key: keyof LuaClass, val: any): void {
+    let tbl = classTable;
+    do {
+        const setters = rawget(tbl, "____setters");
+        if (setters) {
+            const setter = setters[key];
+            if (setter) {
+                setter(tbl, val);
+                return;
+            }
+        }
+
+        tbl = rawget(tbl, "____super");
+    }
+    while (tbl);
+
+    rawset(classTable, key, val);
+}

--- a/test/unit/accessors.spec.ts
+++ b/test/unit/accessors.spec.ts
@@ -1,7 +1,6 @@
-import { Expect, Test, FocusTests } from "alsatian";
+import { Expect, Test } from "alsatian";
 import * as util from "../src/util";
 
-@FocusTests
 export class AccessorTests {
     @Test("get accessor")
     public getAccessor(): void {

--- a/test/unit/accessors.spec.ts
+++ b/test/unit/accessors.spec.ts
@@ -1,14 +1,14 @@
-import { Expect, Test } from "alsatian";
+import { Expect, Test, FocusTests } from "alsatian";
 import * as util from "../src/util";
 
+@FocusTests
 export class AccessorTests {
     @Test("get accessor")
     public getAccessor(): void {
         const code =
             `class Foo {
-                _foo;
+                _foo = "foo";
                 get foo() { return this._foo; }
-                constructor(){ this._foo = "foo"; }
             }
             const f = new Foo();
             return f.foo;`;
@@ -19,9 +19,8 @@ export class AccessorTests {
     public getAccessorInBaseClass(): void {
         const code =
             `class Foo {
-                _foo;
+                _foo = "foo";
                 get foo() { return this._foo; }
-                constructor(){ this._foo = "foo"; }
             }
             class Bar extends Foo {}
             const b = new Bar();
@@ -33,21 +32,23 @@ export class AccessorTests {
     public getAccessorOverride(): void {
         const code =
             `class Foo {
+                _foo = "foo";
                 foo = "foo";
             }
             class Bar extends Foo {
-                get foo() { return "bar"; }
+                get foo() { return this._foo + "bar"; }
             }
             const b = new Bar();
             return b.foo;`;
-        Expect(util.transpileAndExecute(code)).toBe("bar");
+        Expect(util.transpileAndExecute(code)).toBe("foobar");
     }
 
     @Test("get accessor overridden")
     public getAccessorOverridden(): void {
         const code =
             `class Foo {
-                get foo() { return "foo"; }
+                _foo = "foo";
+                get foo() { return this._foo; }
             }
             class Bar extends Foo {
                 foo = "bar";
@@ -61,10 +62,12 @@ export class AccessorTests {
     public getAccessorOverrideAccessor(): void {
         const code =
             `class Foo {
-                get foo() { return "foo"; }
+                _foo = "foo";
+                get foo() { return this._foo; }
             }
             class Bar extends Foo {
-                get foo() { return "bar"; }
+                _bar = "bar";
+                get foo() { return this._bar; }
             }
             const b = new Bar();
             return b.foo;`;
@@ -75,7 +78,8 @@ export class AccessorTests {
     public getAccessorFromINterface(): void {
         const code =
             `class Foo {
-                get foo() { return "foo"; }
+                _foo = "foo";
+                get foo() { return this._foo; }
             }
             interface Bar {
                 readonly foo: string;
@@ -89,12 +93,12 @@ export class AccessorTests {
     public setAccessor(): void {
         const code =
             `class Foo {
-                prop = "prop";
-                set foo(val: string) { this.prop = val; }
+                _foo = "foo";
+                set foo(val: string) { this._foo = val; }
             }
             const f = new Foo();
             f.foo = "bar"
-            return f.prop;`;
+            return f._foo;`;
         Expect(util.transpileAndExecute(code)).toBe("bar");
     }
 
@@ -102,13 +106,13 @@ export class AccessorTests {
     public setAccessorInBaseClass(): void {
         const code =
             `class Foo {
-                prop = "prop";
-                set foo(val: string) { this.prop = val; }
+                _foo = "foo";
+                set foo(val: string) { this._foo = val; }
             }
             class Bar extends Foo {}
             const b = new Bar();
             b.foo = "bar"
-            return b.prop;`;
+            return b._foo;`;
         Expect(util.transpileAndExecute(code)).toBe("bar");
     }
 
@@ -116,15 +120,15 @@ export class AccessorTests {
     public setAccessorOverride(): void {
         const code =
             `class Foo {
-                prop = "prop";
+                _foo = "foo";
                 foo = "foo";
             }
             class Bar extends Foo {
-                set foo(val: string) { this.prop = val; }
+                set foo(val: string) { this._foo = val; }
             }
             const b = new Bar();
             b.foo = "bar"
-            return b.prop;`;
+            return b._foo;`;
         Expect(util.transpileAndExecute(code)).toBe("bar");
     }
 
@@ -132,16 +136,16 @@ export class AccessorTests {
     public setAccessorOverridden(): void {
         const code =
             `class Foo {
-                prop = "prop";
-                set foo(val: string) { this.prop = val; }
+                _foo = "baz";
+                set foo(val: string) { this._foo = val; }
             }
             class Bar extends Foo {
                 foo = "foo"; // triggers base class setter
             }
             const b = new Bar();
-            const propOriginal = b.prop;
+            const fooOriginal = b._foo;
             b.foo = "bar"
-            return propOriginal + b.prop;`;
+            return fooOriginal + b._foo;`;
         Expect(util.transpileAndExecute(code)).toBe("foobar");
     }
 
@@ -149,15 +153,15 @@ export class AccessorTests {
     public setAccessorOverrideAccessor(): void {
         const code =
             `class Foo {
-                prop = "prop";
-                set foo(val: string) { this.prop = "foo"; }
+                _foo = "foo";
+                set foo(val: string) { this._foo = "foo"; }
             }
             class Bar extends Foo {
-                set foo(val: string) { this.prop = val; }
+                set foo(val: string) { this._foo = val; }
             }
             const b = new Bar();
             b.foo = "bar"
-            return b.prop;`;
+            return b._foo;`;
         Expect(util.transpileAndExecute(code)).toBe("bar");
     }
 
@@ -165,16 +169,245 @@ export class AccessorTests {
     public setAccessorFromInterface(): void {
         const code =
             `class Foo {
-                prop = "prop";
-                set foo(val: string) { this.prop = val; }
+                _foo = "foo";
+                set foo(val: string) { this._foo = val; }
             }
             interface Bar {
-                prop: string;
+                _foo: string;
                 foo: string;
             }
             const b: Bar = new Foo();
             b.foo = "bar"
-            return b.prop;`;
+            return b._foo;`;
         Expect(util.transpileAndExecute(code)).toBe("bar");
+    }
+
+    @Test("get/set accessors")
+    public getSetAccessor(): void {
+        const code =
+            `class Foo {
+                _foo = "foo";
+                get foo() { return this._foo; }
+                set foo(val: string) { this._foo = val; }
+            }
+            const f = new Foo();
+            const fooOriginal = f.foo;
+            f.foo = "bar";
+            return fooOriginal + f.foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("foobar");
+    }
+
+    @Test("get/set accessors in base class")
+    public getSetAccessorInBaseClass(): void {
+        const code =
+            `class Foo {
+                _foo = "foo";
+                get foo() { return this._foo; }
+                set foo(val: string) { this._foo = val; }
+            }
+            class Bar extends Foo {}
+            const b = new Bar();
+            const fooOriginal = b.foo;
+            b.foo = "bar"
+            return fooOriginal + b.foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("foobar");
+    }
+
+    @Test("static get accessor")
+    public staticGetAccessor(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static get foo() { return this._foo; }
+            }
+            return Foo.foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("foo");
+    }
+
+    @Test("static get accessor in base class")
+    public staticGetAccessorInBaseClass(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static get foo() { return this._foo; }
+            }
+            class Bar extends Foo {}
+            return Bar.foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("foo");
+    }
+
+    @Test("static get accessor override")
+    public staticGetAccessorOverride(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static foo = "foo";
+            }
+            class Bar extends Foo {
+                static get foo() { return this._foo + "bar"; }
+            }
+            return Bar.foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("foobar");
+    }
+
+    @Test("static get accessor overridden")
+    public staticGetAccessorOverridden(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static get foo() { return this._foo; }
+            }
+            class Bar extends Foo {
+                static foo = "bar";
+            }
+            return Bar.foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("bar");
+    }
+
+    @Test("static get accessor override accessor")
+    public staticGetAccessorOverrideAccessor(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static get foo() { return this._foo; }
+            }
+            class Bar extends Foo {
+                static _bar = "bar";
+                static get foo() { return this._bar; }
+            }
+            return Bar.foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("bar");
+    }
+
+    @Test("static get accessor from interface")
+    public staticGetAccessorFromINterface(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static get foo() { return this._foo; }
+            }
+            interface Bar {
+                readonly foo: string;
+            }
+            const b: Bar = Foo;
+            return b.foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("foo");
+    }
+
+    @Test("static set accessor")
+    public staticSetAccessor(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static set foo(val: string) { this._foo = val; }
+            }
+            Foo.foo = "bar"
+            return Foo._foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("bar");
+    }
+
+    @Test("static set accessor in base class")
+    public staticSetAccessorInBaseClass(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static set foo(val: string) { this._foo = val; }
+            }
+            class Bar extends Foo {}
+            Bar.foo = "bar"
+            return Bar._foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("bar");
+    }
+
+    @Test("static set accessor override")
+    public staticSetAccessorOverride(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static foo = "foo";
+            }
+            class Bar extends Foo {
+                static set foo(val: string) { this._foo = val; }
+            }
+            Bar.foo = "bar"
+            return Bar._foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("bar");
+    }
+
+    @Test("static set accessor overridden")
+    public staticSetAccessorOverridden(): void {
+        const code =
+            `class Foo {
+                static _foo = "baz";
+                static set foo(val: string) { this._foo = val; }
+            }
+            class Bar extends Foo {
+                static foo = "foo"; // triggers base class setter
+            }
+            const fooOriginal = Bar._foo;
+            Bar.foo = "bar"
+            return fooOriginal + Bar._foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("foobar");
+    }
+
+    @Test("static set accessor override accessor")
+    public staticSetAccessorOverrideAccessor(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static set foo(val: string) { this._foo = "foo"; }
+            }
+            class Bar extends Foo {
+                static set foo(val: string) { this._foo = val; }
+            }
+            Bar.foo = "bar"
+            return Bar._foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("bar");
+    }
+
+    @Test("static set accessor from interface")
+    public staticSetAccessorFromInterface(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static set foo(val: string) { this._foo = val; }
+            }
+            interface Bar {
+                _foo: string;
+                foo: string;
+            }
+            const b: Bar = Foo;
+            b.foo = "bar"
+            return b._foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("bar");
+    }
+
+    @Test("static get/set accessors")
+    public staticGetSetAccessor(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static get foo() { return this._foo; }
+                static set foo(val: string) { this._foo = val; }
+            }
+            const fooOriginal = Foo.foo;
+            Foo.foo = "bar";
+            return fooOriginal + Foo.foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("foobar");
+    }
+
+    @Test("static get/set accessors in base class")
+    public staticGetSetAccessorInBaseClass(): void {
+        const code =
+            `class Foo {
+                static _foo = "foo";
+                static get foo() { return this._foo; }
+                static set foo(val: string) { this._foo = val; }
+            }
+            class Bar extends Foo {}
+            const fooOriginal = Bar.foo;
+            Bar.foo = "bar"
+            return fooOriginal + Bar.foo;`;
+        Expect(util.transpileAndExecute(code)).toBe("foobar");
     }
 }


### PR DESCRIPTION
These actually broke with the class+prototype update. This adds support back for them in a similar way to standard get/set accessors. To make that work, class tables need to be given their own metatable to correctly forward things (but classes without static getters/setters are not affected).

There's a also a bit of cleanup in here:
- `____getters` and `____setters` tables are no longer added to derived classes that don't have their own accessors
- all tests have been modified to reference `self` in their getters/setters to ensure problems with `self` not propagating don't occur again