### PR TITLE
Dot slash path fix

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3811,7 +3811,7 @@ export class LuaTransformer {
     }
 
     private getImportPath(relativePath: string): string {
-        const rootDir = this.options.rootDir && path.resolve(this.options.rootDir) || path.resolve(".");
+        const rootDir = this.options.rootDir ? path.resolve(this.options.rootDir) : path.resolve(".");
         const absoluteImportPath = path.format(path.parse(this.getAbsoluteImportPath(relativePath)));
         const absoluteRootDirPath = path.format(path.parse(rootDir));
         if (absoluteImportPath.includes(absoluteRootDirPath)) {

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3811,12 +3811,12 @@ export class LuaTransformer {
     }
 
     private getImportPath(relativePath: string): string {
-        const rootDir = this.options.rootDir || path.resolve(".");
-        const absoluteImportPath = this.formatPathToLuaPath(this.getAbsoluteImportPath(relativePath));
-        const absoluteRootDirPath = this.formatPathToLuaPath(rootDir);
+        const rootDir = this.options.rootDir && path.resolve(this.options.rootDir) || path.resolve(".");
+        const absoluteImportPath = path.format(path.parse(this.getAbsoluteImportPath(relativePath)));
+        const absoluteRootDirPath = path.format(path.parse(rootDir));
         if (absoluteImportPath.includes(absoluteRootDirPath)) {
-            const relativePathToRoot =  absoluteImportPath.replace(absoluteRootDirPath, "").slice(1);
-            return relativePathToRoot;
+            return this.formatPathToLuaPath(
+                absoluteImportPath.replace(absoluteRootDirPath, "").slice(1));
         } else {
             throw TSTLErrors.UnresolvableRequirePath(undefined,
                 `Cannot create require path. Module does not exist within --rootDir`,

--- a/test/unit/require.spec.ts
+++ b/test/unit/require.spec.ts
@@ -7,8 +7,10 @@ import { CompilerOptions } from "../../src/CompilerOptions";
 export class RequireTests {
 
     @TestCase("file.ts", "./folder/Module", "folder.Module", { rootDir: "." }, false)
+    @TestCase("file.ts", "./folder/Module", "folder.Module", { rootDir: "./" }, false)
     @TestCase("src/file.ts", "./folder/Module", "src.folder.Module", { rootDir: "." }, false)
     @TestCase("file.ts", "folder/Module", "folder.Module", { rootDir: ".", baseUrl: "." }, false)
+    @TestCase("file.ts", "folder/Module", "folder.Module", { rootDir: "./", baseUrl: "." }, false)
     @TestCase("src/file.ts", "./folder/Module", "folder.Module", { rootDir: "src" }, false)
     @TestCase("src/file.ts", "./folder/Module", "folder.Module", { rootDir: "./src" }, false)
     @TestCase("file.ts", "../Module", "", { rootDir: "./src" }, true)
@@ -22,7 +24,6 @@ export class RequireTests {
         options: CompilerOptions,
         throwsError: boolean): void {
         const regex = /require\("(.*?)"\)/;                 // This regex extracts `hello` from require("hello")
-        options.rootDir = path.resolve(options.rootDir);    // This happens automatically from the command line
         if (throwsError) {
             Expect(() => util.transpileString(`import * from "${usedPath}";`, options, true, filePath)).toThrow();
         } else {


### PR DESCRIPTION
Fixes #425

I use `path` to parse and format both paths so that there is no leading `/` and the slashes are both the same kind.

Added some tests as well to make sure this stops happening.