### PR TITLE
@luaIterator changed to apply to type, not function

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -165,13 +165,9 @@ export class TSHelper {
         return TSHelper.forTypeOrAnySupertype(type, checker, t => TSHelper.isExplicitArrayType(t, checker));
     }
 
-    public static isLuaIteratorCall(node: ts.Node, checker: ts.TypeChecker): boolean {
-        if (ts.isCallExpression(node) && node.parent && ts.isForOfStatement(node.parent)) {
-            const type = checker.getTypeAtLocation(node.expression);
-            return TSHelper.getCustomDecorators(type, checker).has(DecoratorKind.LuaIterator);
-        } else {
-            return false;
-        }
+    public static isLuaIteratorType(node: ts.Node, checker: ts.TypeChecker): boolean {
+        const type = checker.getTypeAtLocation(node);
+        return TSHelper.getCustomDecorators(type, checker).has(DecoratorKind.LuaIterator);
     }
 
     public static isTupleReturnCall(node: ts.Node, checker: ts.TypeChecker): boolean {
@@ -195,16 +191,6 @@ export class TSHelper {
             }
             const decorators = TSHelper.getCustomDecorators(functionType, checker);
             return decorators.has(DecoratorKind.TupleReturn);
-        } else {
-            return false;
-        }
-    }
-
-    public static isInLuaIteratorFunction(node: ts.Node, checker: ts.TypeChecker): boolean {
-        const declaration = TSHelper.findFirstNodeAbove(node, ts.isFunctionLike);
-        if (declaration) {
-            const decorators = TSHelper.getCustomDecorators(checker.getTypeAtLocation(declaration), checker);
-            return decorators.has(DecoratorKind.LuaIterator);
         } else {
             return false;
         }

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -525,7 +525,8 @@ export class LuaLoopTests
     public forofLuaIterator(): void {
         const code = `const arr = ["a", "b", "c"];
             /** @luaIterator */
-            function luaIter(): Iterable<string> {
+            interface Iter extends Iterable<string> {}
+            function luaIter(): Iter {
                 let i = 0;
                 return (() => arr[i++]) as any;
             }
@@ -545,7 +546,8 @@ export class LuaLoopTests
     public forofLuaIteratorExistingVar(): void {
         const code = `const arr = ["a", "b", "c"];
             /** @luaIterator */
-            function luaIter(): Iterable<string> {
+            interface Iter extends Iterable<string> {}
+            function luaIter(): Iter {
                 let i = 0;
                 return (() => arr[i++]) as any;
             }
@@ -566,7 +568,8 @@ export class LuaLoopTests
     public forofLuaIteratorDestructuring(): void {
         const code = `const arr = ["a", "b", "c"];
             /** @luaIterator */
-            function luaIter(): Iterable<[string, string]> {
+            interface Iter extends Iterable<[string, string]> {}
+            function luaIter(): Iter {
                 let i = 0;
                 return (() => arr[i] && [i.toString(), arr[i++]]) as any;
             }
@@ -586,7 +589,8 @@ export class LuaLoopTests
     public forofLuaIteratorDestructuringExistingVar(): void {
         const code = `const arr = ["a", "b", "c"];
             /** @luaIterator */
-            function luaIter(): Iterable<[string, string]> {
+            interface Iter extends Iterable<[string, string]> {}
+            function luaIter(): Iter {
                 let i = 0;
                 return (() => arr[i] && [i.toString(), arr[i++]]) as any;
             }
@@ -609,7 +613,8 @@ export class LuaLoopTests
         const code = `const arr = ["a", "b", "c"];
             /** @luaIterator */
             /** @tupleReturn */
-            function luaIter(): Iterable<[string, string]> {
+            interface Iter extends Iterable<[string, string]> {}
+            function luaIter(): Iter {
                 let i = 0;
                 /** @tupleReturn */
                 function iter() { return arr[i] && [i.toString(), arr[i++]] || []; }
@@ -632,7 +637,8 @@ export class LuaLoopTests
         const code = `const arr = ["a", "b", "c"];
             /** @luaIterator */
             /** @tupleReturn */
-            function luaIter(): Iterable<[string, string]> {
+            interface Iter extends Iterable<[string, string]> {}
+            function luaIter(): Iter {
                 let i = 0;
                 /** @tupleReturn */
                 function iter() { return arr[i] && [i.toString(), arr[i++]] || []; }
@@ -656,7 +662,8 @@ export class LuaLoopTests
     public forofLuaIteratorTupleReturnSingleVar(): void {
         const code = `/** @luaIterator */
             /** @tupleReturn */
-            declare function luaIter(): Iterable<[string, string]>;
+            interface Iter extends Iterable<[string, string]> {}
+            declare function luaIter(): Iter;
             for (let x of luaIter()) {}`;
         const compilerOptions = {
             luaLibImport: LuaLibImportKind.Require,
@@ -674,7 +681,8 @@ export class LuaLoopTests
     public forofLuaIteratorTupleReturnSingleExistingVar(): void {
         const code = `/** @luaIterator */
             /** @tupleReturn */
-            declare function luaIter(): Iterable<[string, string]>;
+            interface Iter extends Iterable<[string, string]> {}
+            declare function luaIter(): Iter;
             let x: [string, string];
             for (x of luaIter()) {}`;
         const compilerOptions = {
@@ -694,14 +702,15 @@ export class LuaLoopTests
         const code =
             `const arr = ["a", "b", "c"];
             /** @luaIterator */
-            function luaIter(): Iterable<string> {
+            interface Iter extends Iterable<string> {}
+            function luaIter(): Iter {
                 let i = 0;
                 function iter() { return arr[i++]; }
                 return iter as any;
             }
-            /** @luaIterator */
-            function forward(): Iterable<string> {
-                return luaIter();
+            function forward() {
+                const iter = luaIter();
+                return iter;
             }
             let result = "";
             for (let a of forward()) { result += a; }
@@ -721,16 +730,16 @@ export class LuaLoopTests
             `const arr = ["a", "b", "c"];
             /** @luaIterator */
             /** @tupleReturn */
-            function luaIter(): Iterable<[string, string]> {
+            interface Iter extends Iterable<[string, string]> {}
+            function luaIter(): Iter {
                 let i = 0;
                 /** @tupleReturn */
                 function iter() { return arr[i] && [i.toString(), arr[i++]] || []; }
                 return iter as any;
             }
-            /** @luaIterator */
-            /** @tupleReturn */
-            function forward(): Iterable<[string, string]> {
-                return luaIter();
+            function forward() {
+                const iter = luaIter();
+                return iter;
             }
             let result = "";
             for (let [a, b] of forward()) { result += a + b; }


### PR DESCRIPTION
fixes #396

Currently, the `@luaIterator` directive is applied to a function that generates an iterator. This causes issues with tracking that a type is a lua iterator for use in for...of loops.

```ts
declare namespace string {
    /** @luaIterator @tupleReturn */
    export function gmatch(s: string, pattern: string): Iterable<string[]>;
}

const iter = string.gmatch("foobar", ".");
for (const [c] of iter) {} // 'iter' is seen as a regular Iterable and won't transpile correctly here
```

This PR changes the `@luaIterator` so that it is applied to the type itself:
```ts
declare namespace string {
    /** @luaIterator @tupleReturn */
    export interface GmatchResult extends Iterable<string[]> {}
    export function gmatch(s: string, pattern: string): GmatchResult;
}
```
This allows that iterator to be passed around freely without losing the directive. It will correctly transpile to a native for...in loop regardless of its source.

Note this is a breaking change! But the old way was error-prone and inconsistent with how other directives work, so I believe it's worth requiring declarations to be updated.
