### PR TITLE
fix Number constants

### DIFF
--- a/src/transformation/builtins/number.ts
+++ b/src/transformation/builtins/number.ts
@@ -77,31 +77,62 @@ export function transformNumberProperty(
                 node
             );
         case "MIN_VALUE":
+            // 2 ^ -1074 = 5e-324 (smallest positive double)
             return lua.createBinaryExpression(
-                lua.createNumericLiteral(-2),
-                lua.createNumericLiteral(1074),
+                lua.createNumericLiteral(2),
+                lua.createNumericLiteral(-1074),
                 lua.SyntaxKind.PowerOperator,
                 node
             );
         case "MIN_SAFE_INTEGER":
-            return lua.createBinaryExpression(
-                lua.createNumericLiteral(-2),
-                lua.createNumericLiteral(1074),
-                lua.SyntaxKind.PowerOperator,
+            // -(2 ^ 53 - 1) = -9007199254740991
+            return lua.createUnaryExpression(
+                lua.createParenthesizedExpression(
+                    lua.createBinaryExpression(
+                        lua.createBinaryExpression(
+                            lua.createNumericLiteral(2),
+                            lua.createNumericLiteral(53),
+                            lua.SyntaxKind.PowerOperator
+                        ),
+                        lua.createNumericLiteral(1),
+                        lua.SyntaxKind.SubtractionOperator
+                    )
+                ),
+                lua.SyntaxKind.NegationOperator,
                 node
             );
         case "MAX_SAFE_INTEGER":
+            // 2 ^ 53 - 1 = 9007199254740991
             return lua.createBinaryExpression(
-                lua.createNumericLiteral(2),
-                lua.createNumericLiteral(1024),
-                lua.SyntaxKind.PowerOperator,
+                lua.createBinaryExpression(
+                    lua.createNumericLiteral(2),
+                    lua.createNumericLiteral(53),
+                    lua.SyntaxKind.PowerOperator
+                ),
+                lua.createNumericLiteral(1),
+                lua.SyntaxKind.SubtractionOperator,
                 node
             );
         case "MAX_VALUE":
+            // (2 - 2 ^ -52) * 2 ^ 1023 = 1.7976931348623157e+308
             return lua.createBinaryExpression(
-                lua.createNumericLiteral(2),
-                lua.createNumericLiteral(1024),
-                lua.SyntaxKind.PowerOperator,
+                lua.createParenthesizedExpression(
+                    lua.createBinaryExpression(
+                        lua.createNumericLiteral(2),
+                        lua.createBinaryExpression(
+                            lua.createNumericLiteral(2),
+                            lua.createNumericLiteral(-52),
+                            lua.SyntaxKind.PowerOperator
+                        ),
+                        lua.SyntaxKind.SubtractionOperator
+                    )
+                ),
+                lua.createBinaryExpression(
+                    lua.createNumericLiteral(2),
+                    lua.createNumericLiteral(1023),
+                    lua.SyntaxKind.PowerOperator
+                ),
+                lua.SyntaxKind.MultiplicationOperator,
                 node
             );
 

--- a/test/unit/builtins/numbers.spec.ts
+++ b/test/unit/builtins/numbers.spec.ts
@@ -212,17 +212,23 @@ test.each(["42", "undefined"])("prototype call on nullable number (%p)", value =
 });
 
 test.each([
-    "Number.NEGATIVE_INFINITY <= Number.MIN_VALUE",
-    "Number.MIN_VALUE <= Number.MIN_SAFE_INTEGER",
-
-    "Number.MAX_SAFE_INTEGER <= Number.MAX_VALUE",
-    "Number.MAX_VALUE <= Number.POSITIVE_INFINITY",
+    // Full ordering: NEG_INF < MIN_SAFE < 0 < MIN_VALUE < EPSILON < MAX_SAFE < MAX_VALUE < POS_INF
+    "Number.NEGATIVE_INFINITY < Number.MIN_SAFE_INTEGER",
     "Number.MIN_SAFE_INTEGER < 0",
-
-    "0 < Number.EPSILON",
+    "0 < Number.MIN_VALUE",
+    "Number.MIN_VALUE < Number.EPSILON",
     "Number.EPSILON < Number.MAX_SAFE_INTEGER",
-])("Numer constants have correct relative sizes (%p)", comparison => {
-    util.testExpression(comparison).expectToEqual(true);
+    "Number.MAX_SAFE_INTEGER < Number.MAX_VALUE",
+    "Number.MAX_VALUE < Number.POSITIVE_INFINITY",
+
+    // Verify specific values
+    "Number.MIN_VALUE > 0",
+    "Number.MIN_SAFE_INTEGER === -(2**53 - 1)",
+    "Number.MAX_SAFE_INTEGER === 2**53 - 1",
+    "Number.MAX_SAFE_INTEGER + 1 !== Number.MAX_SAFE_INTEGER",
+    "Number.MIN_SAFE_INTEGER - 1 !== Number.MIN_SAFE_INTEGER",
+])("Number constants have correct relative sizes (%p)", comparison => {
+    util.testExpression(comparison).expectToMatchJsResult();
 });
 
 // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1629


### PR DESCRIPTION
For reference, the correct ordering is: `NEGATIVE_INFINITY < MIN_SAFE_INTEGER < 0 < MIN_VALUE < EPSILON < MAX_SAFE_INTEGER < MAX_VALUE < POSITIVE_INFINITY`

All four `Number` constants emit wrong Lua: they all end up as `inf` or `-inf`

| Constant | Before (wrong) | After (correct) |
|---|---|---|
| `MAX_SAFE_INTEGER` | `2 ^ 1024` → `inf` | `2 ^ 53 - 1` |
| `MIN_SAFE_INTEGER` | `-2 ^ 1074` → `-inf` | `-(2 ^ 53 - 1)` |
| `MIN_VALUE` | `-2 ^ 1074` → `-inf` | `2 ^ -1074` |
| `MAX_VALUE` | `2 ^ 1024` → `inf` | `(2 - 2 ^ -52) * 2 ^ 1023` |

Also `MIN_SAFE_INTEGER` and `MIN_VALUE` were emitting identical code, same for `MAX_SAFE_INTEGER` and `MAX_VALUE`.

You can verify with:

```ts
console.log("MAX_SAFE_INTEGER:", Number.MAX_SAFE_INTEGER);  // 9007199254740991
console.log("MIN_SAFE_INTEGER:", Number.MIN_SAFE_INTEGER);  // -9007199254740991
console.log("MIN_VALUE:", Number.MIN_VALUE);                // 5e-324
console.log("MAX_VALUE:", Number.MAX_VALUE);                // 1.7976931348623157e+308
```

See [Number on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) for the correct values.

Repro in the TSTL playground: https://typescripttolua.github.io/play/#code/5.4/MYewdgziA2CmB00QHMAUAiAsgQQBoH0BlbAMQFF8BJAOQBUyBxMgJQC50AaAAmoFcBbAEawATvBwFi5KnUYsAlAG4uXAPSquATgAM2gOwBGTZoBMAVgAsei9uMGAUKEgwESNFhpFSFGvSZtOHgFhMUxPKR9ZfyUVdS4AWh19I1NLa1tNBycoOEQUDDDqfAA1bAAZAFUydm4+IVFxT1LKshiVdo7OtQ0zWHiAZhMLR3Ac13ysPBLyqpqg+tCp5qq2rrXurgN4PU09ADZNfoN+iwAOPZMjsz1YAGp+7VOgA

The existing test didn't catch this because it used `expectToEqual(true)` with comparisons that the wrong values accidentally satisfied (e.g. `-inf <= -inf` is `true`). Switched to `expectToMatchJsResult` with stricter comparisons that actually verify the ordering and specific values.
