### PR TITLE
fix Math.atan2 emitting math.atan2 instead of math.atan for Lua 5.4+

### DIFF
--- a/src/transformation/builtins/math.ts
+++ b/src/transformation/builtins/math.ts
@@ -42,14 +42,18 @@ export function transformMathCall(
 
     const expressionName = calledMethod.name.text;
     switch (expressionName) {
-        // Lua 5.3: math.atan(y, x)
+        // Lua 5.3+: math.atan(y, x)
         // Otherwise: math.atan2(y, x)
         case "atan2": {
             if (context.luaTarget === LuaTarget.Universal) {
                 return transformLuaLibFunction(context, LuaLibFeature.MathAtan2, node, ...params);
             }
 
-            const method = lua.createStringLiteral(context.luaTarget === LuaTarget.Lua53 ? "atan" : "atan2");
+            const useAtan =
+                context.luaTarget === LuaTarget.Lua53 ||
+                context.luaTarget === LuaTarget.Lua54 ||
+                context.luaTarget === LuaTarget.Lua55;
+            const method = lua.createStringLiteral(useAtan ? "atan" : "atan2");
             return lua.createCallExpression(lua.createTableIndexExpression(math, method), params, node);
         }
 

--- a/src/transformation/builtins/math.ts
+++ b/src/transformation/builtins/math.ts
@@ -49,11 +49,13 @@ export function transformMathCall(
                 return transformLuaLibFunction(context, LuaLibFeature.MathAtan2, node, ...params);
             }
 
-            const useAtan =
-                context.luaTarget === LuaTarget.Lua53 ||
-                context.luaTarget === LuaTarget.Lua54 ||
-                context.luaTarget === LuaTarget.Lua55;
-            const method = lua.createStringLiteral(useAtan ? "atan" : "atan2");
+            const useAtan2 =
+                context.luaTarget === LuaTarget.Lua50 ||
+                context.luaTarget === LuaTarget.Lua51 ||
+                context.luaTarget === LuaTarget.Lua52 ||
+                context.luaTarget === LuaTarget.LuaJIT ||
+                context.luaTarget === LuaTarget.Luau;
+            const method = lua.createStringLiteral(useAtan2 ? "atan2" : "atan");
             return lua.createCallExpression(lua.createTableIndexExpression(math, method), params, node);
         }
 

--- a/test/unit/builtins/math.spec.ts
+++ b/test/unit/builtins/math.spec.ts
@@ -95,8 +95,8 @@ util.testEachVersion("Math.atan2", () => util.testExpression`Math.atan2(4, 5)`, 
     [tstl.LuaTarget.Lua51]: builder => builder.tap(expectMathAtan2),
     [tstl.LuaTarget.Lua52]: builder => builder.tap(expectMathAtan2),
     [tstl.LuaTarget.Lua53]: builder => builder.tap(expectMathAtan),
-    [tstl.LuaTarget.Lua54]: builder => builder.tap(expectMathAtan2),
-    [tstl.LuaTarget.Lua55]: builder => builder.tap(expectMathAtan2),
+    [tstl.LuaTarget.Lua54]: builder => builder.tap(expectMathAtan),
+    [tstl.LuaTarget.Lua55]: builder => builder.tap(expectMathAtan),
     [tstl.LuaTarget.Luau]: builder => builder.tap(expectMathAtan2),
 });
 


### PR DESCRIPTION
`Math.atan2(y, x)` emits `math.atan2(y, x)` for Lua 5.4 and 5.5 targets, but `math.atan2` was deprecated in 5.3 (replaced by two-arg `math.atan(y, x)`). 5.3 still has both, and 5.4 keeps `math.atan2` behind `-DLUA_COMPAT_5_3` (hardcoded in the stock Makefile). 5.5 drops the compat flag, so `math.atan2` is just `nil` and you get a runtime error.

The codegen only special-cased `=== Lua53` when choosing `math.atan` vs `math.atan2`. That was correct when written (2019, before 5.4/5.5 targets existed) but never got updated when those targets were added.

Tests didn't catch this because `getLuaBindingsForVersion` in test/util.ts falls through to the 5.4 WASM for 5.5, and the 5.4 WASM is built with compat enabled, so `math.atan2` exists and the test passes.
