### PR TITLE
fix >>> (unsigned right shift) producing wrong results on Lua 5.3+

### DIFF
--- a/src/transformation/visitors/binary-expression/bit.ts
+++ b/src/transformation/visitors/binary-expression/bit.ts
@@ -75,6 +75,22 @@ export function transformBinaryBitOperation(
         case LuaTarget.Lua52:
             return transformBinaryBitLibOperation(node, left, right, operator, "bit32");
         default:
+            // Lua 5.3+ `>>` is arithmetic (sign-extending), but TS `>>>` is logical (zero-fill).
+            // Emit `(left & 0xFFFFFFFF) >> right` to convert to unsigned 32-bit first.
+            if (operator === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken) {
+                const mask = lua.createBinaryExpression(
+                    left,
+                    lua.createNumericLiteral(0xffffffff, node),
+                    lua.SyntaxKind.BitwiseAndOperator,
+                    node
+                );
+                return lua.createBinaryExpression(
+                    lua.createParenthesizedExpression(mask, node),
+                    right,
+                    lua.SyntaxKind.BitwiseRightShiftOperator,
+                    node
+                );
+            }
             const luaOperator = transformBitOperatorToLuaOperator(context, node, operator);
             return lua.createBinaryExpression(left, right, luaOperator, node);
     }

--- a/test/unit/__snapshots__/expressions.spec.ts.snap
+++ b/test/unit/__snapshots__/expressions.spec.ts.snap
@@ -374,14 +374,14 @@ return ____exports"
 
 exports[`Bitop [5.3] ("a>>>=b") 1`] = `
 "local ____exports = {}
-a = a >> b
+a = (a & 4294967295) >> b
 ____exports.__result = a
 return ____exports"
 `;
 
 exports[`Bitop [5.3] ("a>>>b") 1`] = `
 "local ____exports = {}
-____exports.__result = a >> b
+____exports.__result = (a & 4294967295) >> b
 return ____exports"
 `;
 
@@ -445,14 +445,14 @@ return ____exports"
 
 exports[`Bitop [5.4] ("a>>>=b") 1`] = `
 "local ____exports = {}
-a = a >> b
+a = (a & 4294967295) >> b
 ____exports.__result = a
 return ____exports"
 `;
 
 exports[`Bitop [5.4] ("a>>>b") 1`] = `
 "local ____exports = {}
-____exports.__result = a >> b
+____exports.__result = (a & 4294967295) >> b
 return ____exports"
 `;
 
@@ -516,14 +516,14 @@ return ____exports"
 
 exports[`Bitop [5.5] ("a>>>=b") 1`] = `
 "local ____exports = {}
-a = a >> b
+a = (a & 4294967295) >> b
 ____exports.__result = a
 return ____exports"
 `;
 
 exports[`Bitop [5.5] ("a>>>b") 1`] = `
 "local ____exports = {}
-____exports.__result = a >> b
+____exports.__result = (a & 4294967295) >> b
 return ____exports"
 `;
 

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -119,42 +119,31 @@ test.each(unsupportedIn53And54)("Unsupported bitop 5.4 (%p)", input => {
 
 // Execution tests: verify >>> produces correct results matching JS semantics
 for (const expression of ["-5 >>> 0", "-1 >>> 0", "1 >>> 0", "-1 >>> 16", "255 >>> 4"]) {
-    util.testEachVersion(
-        `Unsigned right shift execution (${expression})`,
-        () => util.testExpression(expression),
-        {
-            [tstl.LuaTarget.Universal]: false,
-            [tstl.LuaTarget.Lua50]: false, // No bit library in WASM runtime
-            [tstl.LuaTarget.Lua51]: false, // No bit library in WASM runtime
-            [tstl.LuaTarget.Lua52]: builder => builder.expectToMatchJsResult(),
-            [tstl.LuaTarget.Lua53]: builder => builder.expectToMatchJsResult(),
-            [tstl.LuaTarget.Lua54]: builder => builder.expectToMatchJsResult(),
-            [tstl.LuaTarget.Lua55]: builder => builder.expectToMatchJsResult(),
-            [tstl.LuaTarget.LuaJIT]: false, // Can't execute LuaJIT in tests
-            [tstl.LuaTarget.Luau]: false,
-        }
-    );
+    util.testEachVersion(`Unsigned right shift execution (${expression})`, () => util.testExpression(expression), {
+        [tstl.LuaTarget.Universal]: false,
+        [tstl.LuaTarget.Lua50]: false, // No bit library in WASM runtime
+        [tstl.LuaTarget.Lua51]: false, // No bit library in WASM runtime
+        [tstl.LuaTarget.Lua52]: builder => builder.expectToMatchJsResult(),
+        [tstl.LuaTarget.Lua53]: builder => builder.expectToMatchJsResult(),
+        [tstl.LuaTarget.Lua54]: builder => builder.expectToMatchJsResult(),
+        [tstl.LuaTarget.Lua55]: builder => builder.expectToMatchJsResult(),
+        [tstl.LuaTarget.LuaJIT]: false, // Can't execute LuaJIT in tests
+        [tstl.LuaTarget.Luau]: false,
+    });
 }
 
-for (const code of [
-    "let a = -5; a >>>= 0; return a;",
-    "let a = -1; a >>>= 16; return a;",
-]) {
-    util.testEachVersion(
-        `Unsigned right shift assignment execution (${code})`,
-        () => util.testFunction(code),
-        {
-            [tstl.LuaTarget.Universal]: false,
-            [tstl.LuaTarget.Lua50]: false, // No bit library in WASM runtime
-            [tstl.LuaTarget.Lua51]: false, // No bit library in WASM runtime
-            [tstl.LuaTarget.Lua52]: builder => builder.expectToMatchJsResult(),
-            [tstl.LuaTarget.Lua53]: builder => builder.expectToMatchJsResult(),
-            [tstl.LuaTarget.Lua54]: builder => builder.expectToMatchJsResult(),
-            [tstl.LuaTarget.Lua55]: builder => builder.expectToMatchJsResult(),
-            [tstl.LuaTarget.LuaJIT]: false, // Can't execute LuaJIT in tests
-            [tstl.LuaTarget.Luau]: false,
-        }
-    );
+for (const code of ["let a = -5; a >>>= 0; return a;", "let a = -1; a >>>= 16; return a;"]) {
+    util.testEachVersion(`Unsigned right shift assignment execution (${code})`, () => util.testFunction(code), {
+        [tstl.LuaTarget.Universal]: false,
+        [tstl.LuaTarget.Lua50]: false, // No bit library in WASM runtime
+        [tstl.LuaTarget.Lua51]: false, // No bit library in WASM runtime
+        [tstl.LuaTarget.Lua52]: builder => builder.expectToMatchJsResult(),
+        [tstl.LuaTarget.Lua53]: builder => builder.expectToMatchJsResult(),
+        [tstl.LuaTarget.Lua54]: builder => builder.expectToMatchJsResult(),
+        [tstl.LuaTarget.Lua55]: builder => builder.expectToMatchJsResult(),
+        [tstl.LuaTarget.LuaJIT]: false, // Can't execute LuaJIT in tests
+        [tstl.LuaTarget.Luau]: false,
+    });
 }
 
 test.each(["1+1", "-1+1", "1*30+4", "1*(3+4)", "1*(3+4*2)", "10-(4+5)"])(

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -117,6 +117,46 @@ test.each(unsupportedIn53And54)("Unsupported bitop 5.4 (%p)", input => {
         .expectDiagnosticsToMatchSnapshot([unsupportedRightShiftOperator.code]);
 });
 
+// Execution tests: verify >>> produces correct results matching JS semantics
+for (const expression of ["-5 >>> 0", "-1 >>> 0", "1 >>> 0", "-1 >>> 16", "255 >>> 4"]) {
+    util.testEachVersion(
+        `Unsigned right shift execution (${expression})`,
+        () => util.testExpression(expression),
+        {
+            [tstl.LuaTarget.Universal]: false,
+            [tstl.LuaTarget.Lua50]: false, // No bit library in WASM runtime
+            [tstl.LuaTarget.Lua51]: false, // No bit library in WASM runtime
+            [tstl.LuaTarget.Lua52]: builder => builder.expectToMatchJsResult(),
+            [tstl.LuaTarget.Lua53]: builder => builder.expectToMatchJsResult(),
+            [tstl.LuaTarget.Lua54]: builder => builder.expectToMatchJsResult(),
+            [tstl.LuaTarget.Lua55]: builder => builder.expectToMatchJsResult(),
+            [tstl.LuaTarget.LuaJIT]: false, // Can't execute LuaJIT in tests
+            [tstl.LuaTarget.Luau]: false,
+        }
+    );
+}
+
+for (const code of [
+    "let a = -5; a >>>= 0; return a;",
+    "let a = -1; a >>>= 16; return a;",
+]) {
+    util.testEachVersion(
+        `Unsigned right shift assignment execution (${code})`,
+        () => util.testFunction(code),
+        {
+            [tstl.LuaTarget.Universal]: false,
+            [tstl.LuaTarget.Lua50]: false, // No bit library in WASM runtime
+            [tstl.LuaTarget.Lua51]: false, // No bit library in WASM runtime
+            [tstl.LuaTarget.Lua52]: builder => builder.expectToMatchJsResult(),
+            [tstl.LuaTarget.Lua53]: builder => builder.expectToMatchJsResult(),
+            [tstl.LuaTarget.Lua54]: builder => builder.expectToMatchJsResult(),
+            [tstl.LuaTarget.Lua55]: builder => builder.expectToMatchJsResult(),
+            [tstl.LuaTarget.LuaJIT]: false, // Can't execute LuaJIT in tests
+            [tstl.LuaTarget.Luau]: false,
+        }
+    );
+}
+
 test.each(["1+1", "-1+1", "1*30+4", "1*(3+4)", "1*(3+4*2)", "10-(4+5)"])(
     "Binary expressions ordering parentheses (%p)",
     input => {


### PR DESCRIPTION
https://typescripttolua.github.io/play/#code/5.4/MYewdgzgLgBGMF4YFoCsBuGXs93-BhRxJpZ+AUKJCADYCmAdLSAOYAU8AfDzAAwBKTFgD0ImABYATAE4JMgGwB2WQEZyGzVu2Eq4CHSYsO6nl35DsYmOp137DjXpoNmbdslO9Bw69LmKKjKoQA

TS >>> is a logical right shift (zero-fills from the left), but TSTL was mapping it to Lua's >> which is arithmetic (sign-extends). This gave wrong results for negative numbers: e.g. -1 >>> 0 should be 4294967295 but produced -1.

Fix by masking to unsigned 32-bit first: (left & 0xFFFFFFFF) >> right. The Lua 5.2 (bit32.rshift) and LuaJIT (bit.rshift) paths were already correct.

```typescript
const n = -5;                                                                                                                
console.log(n >>> 0);   // 4294967291                                                                                              
console.log(1 >>> 0);   // 1                                                                                                       
console.log(-1 >>> 0);  // 4294967295
```