### PR TITLE
fix await inside catch/finally in async try (#1659)

### DIFF
--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -39,38 +39,42 @@ const transformAsyncTry: FunctionVisitor<ts.TryStatement> = (statement, context)
     // local ____try = __TS__AsyncAwaiter(<catch block>)
     const result: lua.Statement[] = [awaiterDefinition];
 
-    if (statement.finallyBlock) {
-        const awaiterFinally = lua.createTableIndexExpression(awaiterIdentifier, lua.createStringLiteral("finally"));
-        const finallyFunction = lua.createFunctionExpression(
-            lua.createBlock(context.transformStatements(statement.finallyBlock.statements))
-        );
-        const finallyCall = lua.createCallExpression(
-            awaiterFinally,
-            [awaiterIdentifier, finallyFunction],
-            statement.finallyBlock
-        );
-        // ____try.finally(<finally function>)
-        result.push(lua.createExpressionStatement(finallyCall));
-    }
-
     if (statement.catchClause) {
-        // ____try.catch(<catch function>)
+        // ____try = ____try.catch(<catch function>)
         const [catchFunction] = transformCatchClause(context, statement.catchClause);
         if (catchFunction.params) {
             catchFunction.params.unshift(lua.createAnonymousIdentifier());
         }
 
+        const catchBodyStatements = catchFunction.body ? catchFunction.body.statements : [];
+        const asyncWrappedCatch = wrapInAsyncAwaiter(context, [...catchBodyStatements], false);
+        catchFunction.body = lua.createBlock([lua.createReturnStatement([asyncWrappedCatch])]);
+
         const awaiterCatch = lua.createTableIndexExpression(awaiterIdentifier, lua.createStringLiteral("catch"));
         const catchCall = lua.createCallExpression(awaiterCatch, [awaiterIdentifier, catchFunction]);
-
-        // await ____try.catch(<catch function>)
-        const promiseAwait = transformLuaLibFunction(context, LuaLibFeature.Await, statement, catchCall);
-        result.push(lua.createExpressionStatement(promiseAwait, statement));
-    } else {
-        // await ____try
-        const promiseAwait = transformLuaLibFunction(context, LuaLibFeature.Await, statement, awaiterIdentifier);
-        result.push(lua.createExpressionStatement(promiseAwait, statement));
+        result.push(lua.createAssignmentStatement(lua.cloneIdentifier(awaiterIdentifier), catchCall));
     }
+
+    if (statement.finallyBlock) {
+        // ____try = ____try.finally(<finally function>)
+        const finallyStatements = context.transformStatements(statement.finallyBlock.statements);
+        const asyncWrappedFinally = wrapInAsyncAwaiter(context, finallyStatements, false);
+        const finallyFunction = lua.createFunctionExpression(
+            lua.createBlock([lua.createReturnStatement([asyncWrappedFinally])])
+        );
+
+        const awaiterFinally = lua.createTableIndexExpression(awaiterIdentifier, lua.createStringLiteral("finally"));
+        const finallyCall = lua.createCallExpression(
+            awaiterFinally,
+            [awaiterIdentifier, finallyFunction],
+            statement.finallyBlock
+        );
+        result.push(lua.createAssignmentStatement(lua.cloneIdentifier(awaiterIdentifier), finallyCall));
+    }
+
+    // __TS__Await(____try)
+    const promiseAwait = transformLuaLibFunction(context, LuaLibFeature.Await, statement, awaiterIdentifier);
+    result.push(lua.createExpressionStatement(promiseAwait, statement));
 
     return result;
 };

--- a/test/unit/builtins/async-await.spec.ts
+++ b/test/unit/builtins/async-await.spec.ts
@@ -815,4 +815,92 @@ describe("try/catch in async function", () => {
             },
         });
     });
+
+    // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1659
+    test("await inside catch handler resolves correctly (#1659)", () => {
+        util.testFunction`
+            let reject: (reason: string) => void = () => {};
+
+            async function failing() {
+                return new Promise((_, rej) => { reject = rej; });
+            }
+
+            async function run() {
+                try {
+                    await failing();
+                } catch (e) {
+                    log("catch");
+                    const a = await Promise.resolve(true);
+                    log("a", a);
+                }
+            }
+
+            run();
+            reject("error");
+
+            return allLogs;
+        `
+            .setTsHeader(promiseTestLib)
+            .expectToEqual(["catch", "a", true]);
+    });
+
+    // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1659
+    test("await inside finally handler resolves correctly (#1659)", () => {
+        util.testFunction`
+            let reject: (reason: string) => void = () => {};
+
+            async function failing() {
+                return new Promise((_, rej) => { reject = rej; });
+            }
+
+            async function run() {
+                try {
+                    await failing();
+                } finally {
+                    log("finally");
+                    const a = await Promise.resolve(true);
+                    log("a", a);
+                }
+            }
+
+            run().catch(() => {});
+            reject("error");
+
+            return allLogs;
+        `
+            .setTsHeader(promiseTestLib)
+            .expectToEqual(["finally", "a", true]);
+    });
+
+    // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1659
+    test("await inside both catch and finally handlers (#1659)", () => {
+        util.testFunction`
+            let reject: (reason: string) => void = () => {};
+
+            async function failing() {
+                return new Promise((_, rej) => { reject = rej; });
+            }
+
+            async function run() {
+                try {
+                    await failing();
+                } catch (e) {
+                    log("catch");
+                    const a = await Promise.resolve("caught");
+                    log("a", a);
+                } finally {
+                    log("finally");
+                    const b = await Promise.resolve("done");
+                    log("b", b);
+                }
+            }
+
+            run();
+            reject("error");
+
+            return allLogs;
+        `
+            .setTsHeader(promiseTestLib)
+            .expectToEqual(["catch", "a", "caught", "finally", "b", "done"]);
+    });
 });

--- a/test/unit/builtins/async-await.spec.ts
+++ b/test/unit/builtins/async-await.spec.ts
@@ -904,6 +904,32 @@ describe("try/catch in async function", () => {
             .expectToEqual(["catch", "a", "caught", "finally", "b", "done"]);
     });
 
+    // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1659
+    test("awaited value in catch is returned from async function (#1659)", () => {
+        util.testFunction`
+            const failing = defer<string>();
+            const recovery = defer<string>();
+
+            async function run() {
+                try {
+                    await failing.promise;
+                    return "succeeded";
+                } catch (e) {
+                    return await recovery.promise;
+                }
+            }
+
+            run().then(value => log("result", value));
+
+            failing.reject("error");
+            recovery.resolve("recovered");
+
+            return allLogs;
+        `
+            .setTsHeader(promiseTestLib)
+            .expectToEqual(["result", "recovered"]);
+    });
+
     // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1706
     test("return inside try with deferred promise (#1706)", () => {
         util.testFunction`


### PR DESCRIPTION
Fixes #1659 

- wrap catch and finally callbacks in `__TS__AsyncAwaiter` so `await` works inside them
- fix the chain ordering (`.catch()` before `.finally()`) and wire up the full chain before awaiting.