### PR TITLE
Fix/object assign non table source (#1642)

### DIFF
--- a/src/lualib/ObjectAssign.ts
+++ b/src/lualib/ObjectAssign.ts
@@ -2,9 +2,10 @@
 export function __TS__ObjectAssign<T extends object>(this: void, target: T, ...sources: T[]): T {
     for (const i of $range(1, sources.length)) {
         const source = sources[i - 1];
-        if (type(source) !== "table") continue;
-        for (const key in source) {
-            target[key] = source[key];
+        if (type(source) === "table") {
+            for (const key in source) {
+                target[key] = source[key];
+            }
         }
     }
 

--- a/src/lualib/ObjectAssign.ts
+++ b/src/lualib/ObjectAssign.ts
@@ -2,6 +2,7 @@
 export function __TS__ObjectAssign<T extends object>(this: void, target: T, ...sources: T[]): T {
     for (const i of $range(1, sources.length)) {
         const source = sources[i - 1];
+        if (type(source) !== "table") continue;
         for (const key in source) {
             target[key] = source[key];
         }

--- a/test/unit/builtins/object.spec.ts
+++ b/test/unit/builtins/object.spec.ts
@@ -10,6 +10,16 @@ test.each([
     util.testExpression`Object.assign(${util.formatCode(initial)}, ${argsString})`.expectToMatchJsResult();
 });
 
+test.each([
+    "Object.assign({}, false)",
+    "Object.assign({}, null)",
+    "Object.assign({}, undefined)",
+    "Object.assign({}, null, undefined)",
+    "Object.assign({ a: 1 }, false, { b: 2 })",
+])("Object.assign skips non-object sources (%p)", expression => {
+    util.testExpression(expression).expectToMatchJsResult();
+});
+
 test.each([{}, { abc: 3 }, { abc: 3, def: "xyz" }])("Object.entries (%p)", obj => {
     const testBuilder = util.testExpressionTemplate`Object.entries(${obj})`;
     // Need custom matcher because order is not guaranteed in neither JS nor Lua

--- a/test/unit/spread.spec.ts
+++ b/test/unit/spread.spec.ts
@@ -119,6 +119,15 @@ describe("in object literal", () => {
         util.testExpression(expression).expectToMatchJsResult();
     });
 
+    test.each([
+        "{ ...((false && { a: 1 }) as any) }",
+        "{ ...((true && { a: 1 }) as any) }",
+        "{ a: 1, ...((false && { b: 2 }) as any) }",
+        "{ ...(null as any), ...(undefined as any) }",
+    ])("of short-circuited operand (%p)", expression => {
+        util.testExpression(expression).expectToMatchJsResult();
+    });
+
     test("of object reference", () => {
         util.testFunction`
             const object = { x: 0, y: 1 };


### PR DESCRIPTION
Fixes #1642 

Issue playground [link](https://typescripttolua.github.io/play/#code/5.4/MYewdgzgLgBCBGArGBeGBvGBrApgTwC4YBGGAXwChRJYwBXAW1RgFkBDKACwDoAnNsABMQDABQBKKuGgw2zAAwwA9EpjyANGu4BWTcSk0Y8Zpm5nR9JgB5ZMAGR24SceQpA)

Minimal repro playground [link](https://typescripttolua.github.io/play/#code/5.4/MYewdgzgLgBCBGArGBeGBvGBrApgTwC4YBGGAXwChRJZ5UMYA6ZgClIB4YAGGAMl7hIAlOSrgIIADY5GkkAHMW8IQG4gA), copied below:

```ts                                                                                                                                       
const obj = { key: 1 };                                                                                                                      
const b = { ...(1 < 0 && obj) };                                                                                                             
console.log(b); // expected: {}                                                                                                              
``` 

`{ ...(cond && obj) }` is a common idiom: when `cond` is falsy, the spread short-circuits to `false` and JS treats it as a no-op (`Object.assign` coerces primitives to wrapper objects with no own enumerable properties). TSTL's `__TS__ObjectAssign` didn't guard against non-table sources, so `pairs(false)` errored at runtime.

## Lualib comp

Old

```lua
local function __TS__ObjectAssign(target, ...)
    local sources = {...}
    for i = 1, #sources do
        local source = sources[i]
        for key in pairs(source) do
            target[key] = source[key]
        end
    end
    return target
end
```

New

```lua
local function __TS__ObjectAssign(target, ...)
    local sources = {...}
    for i = 1, #sources do
        local source = sources[i]
        if type(source) == "table" then
            for key in pairs(source) do
                target[key] = source[key]
            end
        end
    end
    return target
end
```