### PR TITLE
apply pilaoda's fix (#1622)

### DIFF
--- a/src/transformation/utils/typescript/index.ts
+++ b/src/transformation/utils/typescript/index.ts
@@ -14,12 +14,14 @@ export function hasExportEquals(sourceFile: ts.SourceFile): boolean {
  * Search up until finding a node satisfying the callback
  */
 export function findFirstNodeAbove<T extends ts.Node>(node: ts.Node, callback: (n: ts.Node) => n is T): T | undefined {
-    let current = node;
+    // Synthetic nodes (created by pre-transformers like usingTransformer) may have an unset .parent.
+    // Fall back to ts.getOriginalNode so we can still walk the source-parsed parent chain.
+    let current = ts.getOriginalNode(node);
     while (current.parent) {
         if (callback(current.parent)) {
             return current.parent;
         } else {
-            current = current.parent;
+            current = ts.getOriginalNode(current.parent);
         }
     }
 }

--- a/test/unit/using.spec.ts
+++ b/test/unit/using.spec.ts
@@ -194,6 +194,26 @@ test("await using no extra diagnostics (#1571)", () => {
     `.expectToHaveNoDiagnostics();
 });
 
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1622
+test("await-using with nested async arrow that also has await-using (runtime divergence)", () => {
+    util.testFunction`
+        const logs: any[] = [];
+        async function getA(): Promise<AsyncDisposable> {
+            return { [Symbol.asyncDispose]: async () => {} };
+        }
+        async function outer(): Promise<number> {
+            await using a = await getA();
+            const inner = async (): Promise<number> => {
+                await using b = await getA();
+                return 42;
+            };
+            return inner();
+        }
+        outer().then(v => logs.push(v));
+        return logs;
+    `.expectToEqual([42]);
+});
+
 // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1584
 test("works with disposable classes (#1584)", () => {
     util.testFunction`


### PR DESCRIPTION
Fixes #1622 

Just applies @pilaoda 's fix, which works

```typescript
export function findFirstNodeAbove<T extends ts.Node>(node: ts.Node, callback: (n: ts.Node) => n is T): T | undefined {
    let current = ts.getOriginalNode(node);
    while (current.parent) {
        if (callback(current.parent)) {
            return current.parent;
        } else {
            current = ts.getOriginalNode(current.parent);
        }
    }
}
```