### PR TITLE
diagnose unsupported async generators and for-await-of

### DIFF
--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -145,6 +145,12 @@ export const awaitMustBeInAsyncFunction = createErrorDiagnosticFactory(
     "Await can only be used inside async functions."
 );
 
+export const unsupportedAsyncGenerator = createErrorDiagnosticFactory(
+    "Async generator functions are not supported."
+);
+
+export const unsupportedForAwaitOf = createErrorDiagnosticFactory("'for await...of' loops are not supported.");
+
 export const unsupportedBuiltinOptionalCall = createErrorDiagnosticFactory(
     "Optional calls are not supported for builtin or language extension functions."
 );

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -145,9 +145,7 @@ export const awaitMustBeInAsyncFunction = createErrorDiagnosticFactory(
     "Await can only be used inside async functions."
 );
 
-export const unsupportedAsyncGenerator = createErrorDiagnosticFactory(
-    "Async generator functions are not supported."
-);
+export const unsupportedAsyncGenerator = createErrorDiagnosticFactory("Async generator functions are not supported.");
 
 export const unsupportedForAwaitOf = createErrorDiagnosticFactory("'for await...of' loops are not supported.");
 

--- a/src/transformation/visitors/function.ts
+++ b/src/transformation/visitors/function.ts
@@ -16,6 +16,7 @@ import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
 import { transformInPrecedingStatementScope } from "../utils/preceding-statements";
 import { peekScope, performHoisting, Scope, ScopeType } from "../utils/scope";
 import { isFunctionType } from "../utils/typescript";
+import { unsupportedAsyncGenerator } from "../utils/diagnostics";
 import { isAsyncFunction, wrapInAsyncAwaiter } from "./async-await";
 import { transformIdentifier } from "./identifier";
 import { transformExpressionBodyToReturnStatement } from "./return";
@@ -223,6 +224,10 @@ export function transformFunctionToExpression(
     node: ts.FunctionLikeDeclaration
 ): [lua.Expression, Scope] {
     assert(node.body);
+
+    if (node.asteriskToken && isAsyncFunction(node)) {
+        context.diagnostics.push(unsupportedAsyncGenerator(node));
+    }
 
     const type = context.checker.getTypeAtLocation(node);
     let functionContext: lua.Identifier | undefined;

--- a/src/transformation/visitors/loops/for-of.ts
+++ b/src/transformation/visitors/loops/for-of.ts
@@ -11,6 +11,7 @@ import {
 import { isRangeFunction, transformRangeStatement } from "../language-extensions/range";
 import { transformForInitializer, transformLoopBody } from "./utils";
 import { getIterableExtensionKindForNode, IterableExtensionKind } from "../../utils/language-extensions";
+import { unsupportedForAwaitOf } from "../../utils/diagnostics";
 import { assertNever } from "../../../utils";
 
 function transformForOfArrayStatement(
@@ -43,6 +44,10 @@ function transformForOfIteratorStatement(
 }
 
 export const transformForOfStatement: FunctionVisitor<ts.ForOfStatement> = (node, context) => {
+    if (node.awaitModifier) {
+        context.diagnostics.push(unsupportedForAwaitOf(node.awaitModifier));
+    }
+
     const body = lua.createBlock(transformLoopBody(context, node));
 
     if (ts.isCallExpression(node.expression) && isRangeFunction(context, node.expression)) {

--- a/test/unit/builtins/async-await.spec.ts
+++ b/test/unit/builtins/async-await.spec.ts
@@ -1,7 +1,11 @@
 import { ModuleKind, ScriptTarget } from "typescript";
 import { LuaTarget } from "../../../src";
-import { unsupportedForTargetButOverrideAvailable } from "../../../src/transformation/utils/diagnostics";
-import { awaitMustBeInAsyncFunction } from "../../../src/transformation/utils/diagnostics";
+import {
+    awaitMustBeInAsyncFunction,
+    unsupportedAsyncGenerator,
+    unsupportedForAwaitOf,
+    unsupportedForTargetButOverrideAvailable,
+} from "../../../src/transformation/utils/diagnostics";
 import * as util from "../../util";
 
 const promiseTestLib = `
@@ -1122,4 +1126,29 @@ describe("try/catch in async function", () => {
             .setTsHeader(promiseTestLib)
             .expectToEqual(["finally", "ok"]);
     });
+});
+
+describe("async generators are unsupported", () => {
+    test.each([
+        "async function* gen() { yield 1; }",
+        "const gen = async function*() { yield 1; };",
+        "const gen = { async *m() { yield 1; } };",
+        "class C { async *m() { yield 1; } }",
+    ])("diagnoses %p", source => {
+        util.testModule`
+            ${source}
+            export {}
+        `.expectToHaveDiagnostics([unsupportedAsyncGenerator.code]);
+    });
+});
+
+test("for-await-of is unsupported", () => {
+    util.testModule`
+        async function run(items: AsyncIterable<number>) {
+            for await (const x of items) {
+                void x;
+            }
+        }
+        export {}
+    `.expectToHaveDiagnostics([unsupportedForAwaitOf.code]);
 });


### PR DESCRIPTION
https://typescripttolua.github.io/play/#code/5.4/IYZwngdgxgBAZgV2gFwJYHsICoYHMCmEAFAJQwDeAUDDTGKvgDYAmMwA7sKsjAAoBO6ALaoQ+AHT98IdIwBu+IgCJgSkgG5qtek1YcuPAcNESpM+YqUAjNZtp0GLNp259BIsZOmyFyqLcoAX0pKUEhYRBQMCBghLmIyKnsoTBAeKSh8VAVmAC4YNP5UCFwAbQBdGABeGAq7Wjh0fmcDGCIUiDSYKAALJABrGHQ4PEJSRK17GgysnPEABwQQHva+iH6NSZhg+ylkBH4Ymez8ZnFGQlxkHvUYAHo7mHwAD3n8KGRTmABmABo2D4IYCMRhgGAABiCITixVI4muYxiVQAfDB5kUIMg-OgkMgqkoYABqGAQEgaIA

Miscompilation of
- `async function*`
-  `for await...of`

The Lua runs without error but the loop iterates zero times. This adds error diagnostics for both so users get a clear failure at compile time

Some links:
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-3.html#async-iteration
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of

Not sure if in scope though