### PR TITLE
test: run lua 5.5 tests on the lua 5.5 wasm binding

### DIFF
--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -51,6 +51,7 @@ export enum LuaLibFeature {
     DescriptorGet = "DescriptorGet",
     DescriptorSet = "DescriptorSet",
     Error = "Error",
+    ErrorObject = "ErrorObject",
     FunctionBind = "FunctionBind",
     Generator = "Generator",
     InstanceOf = "InstanceOf",

--- a/src/lualib/ErrorObject.ts
+++ b/src/lualib/ErrorObject.ts
@@ -4,6 +4,7 @@
 // protected calls through `xpcall` with a message handler that wraps nil into
 // this sentinel table (Lua 5.5 only mangles nil, not other values), and unwrap
 // on the catch side.
+// See: https://www.lua.org/manual/5.5/manual.html#8.1
 const ____TS__NilErrorObject: any = {};
 
 export function __TS__WrapErrorObject(this: void, value: any): any {

--- a/src/lualib/ErrorObject.ts
+++ b/src/lualib/ErrorObject.ts
@@ -1,0 +1,17 @@
+// Lua 5.5 replaces a `nil` error object with a string ("<no error object>")
+// when an error propagates out of a protected call. This breaks `throw undefined`
+// round-tripping through `pcall`. To preserve the original value, we route
+// protected calls through `xpcall` with a message handler that wraps nil into
+// this sentinel table (Lua 5.5 only mangles nil, not other values), and unwrap
+// on the catch side.
+const ____TS__NilErrorObject: any = {};
+
+export function __TS__WrapErrorObject(this: void, value: any): any {
+    if (value === undefined) return ____TS__NilErrorObject;
+    return value;
+}
+
+export function __TS__UnwrapErrorObject(this: void, value: any): any {
+    if (value === ____TS__NilErrorObject) return undefined;
+    return value;
+}

--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -175,6 +175,7 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
     // is replaced by a string when it propagates out of a protected call. To
     // preserve `throw undefined` semantics, route through xpcall with a message
     // handler that wraps nil into a sentinel, and unwrap before the user catch.
+    // See: https://www.lua.org/manual/5.5/manual.html#8.1
     const wrapErrorObjects =
         context.options.luaTarget === LuaTarget.Lua55 || context.options.luaTarget === LuaTarget.Universal;
     if (wrapErrorObjects) {

--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -4,7 +4,7 @@ import * as lua from "../../LuaAST";
 import { FunctionVisitor, TransformationContext } from "../context";
 import { unsupportedForTarget, unsupportedForTargetButOverrideAvailable } from "../utils/diagnostics";
 import { createUnpackCall } from "../utils/lua-ast";
-import { transformLuaLibFunction } from "../utils/lualib";
+import { importLuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
 import { findScope, LoopContinued, Scope, ScopeType } from "../utils/scope";
 import { isInAsyncFunction, isInGeneratorFunction } from "../utils/typescript";
 import { wrapInAsyncAwaiter } from "./async-await";
@@ -171,8 +171,22 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
     const returnedIdentifier = lua.createIdentifier("____hasReturned");
     let returnCondition: lua.Expression | undefined;
 
-    const pCall = lua.createIdentifier("pcall");
-    const tryCall = lua.createCallExpression(pCall, [lua.createFunctionExpression(tryBlock)]);
+    // On Lua 5.5 (and Universal, which must work on 5.5), a `nil` error object
+    // is replaced by a string when it propagates out of a protected call. To
+    // preserve `throw undefined` semantics, route through xpcall with a message
+    // handler that wraps nil into a sentinel, and unwrap before the user catch.
+    const wrapErrorObjects =
+        context.options.luaTarget === LuaTarget.Lua55 || context.options.luaTarget === LuaTarget.Universal;
+    if (wrapErrorObjects) {
+        importLuaLibFeature(context, LuaLibFeature.ErrorObject);
+    }
+
+    const tryCall = wrapErrorObjects
+        ? lua.createCallExpression(lua.createIdentifier("xpcall"), [
+              lua.createFunctionExpression(tryBlock),
+              lua.createIdentifier("__TS__WrapErrorObject"),
+          ])
+        : lua.createCallExpression(lua.createIdentifier("pcall"), [lua.createFunctionExpression(tryBlock)]);
 
     if (statement.catchClause && statement.catchClause.block.statements.length > 0) {
         // try with catch
@@ -192,9 +206,14 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
         }
         result.push(lua.createVariableDeclarationStatement(tryReturnIdentifiers, tryCall));
 
+        const catchArg = wrapErrorObjects
+            ? lua.createCallExpression(lua.createIdentifier("__TS__UnwrapErrorObject"), [
+                  lua.cloneIdentifier(returnedIdentifier),
+              ])
+            : lua.cloneIdentifier(returnedIdentifier);
         const catchCall = lua.createCallExpression(
             catchIdentifier,
-            statement.catchClause.variableDeclaration ? [lua.cloneIdentifier(returnedIdentifier)] : []
+            statement.catchClause.variableDeclaration ? [catchArg] : []
         );
         const catchCallStatement = hasReturn
             ? lua.createAssignmentStatement(

--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -176,8 +176,9 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
     // preserve `throw undefined` semantics, route through xpcall with a message
     // handler that wraps nil into a sentinel, and unwrap before the user catch.
     // See: https://www.lua.org/manual/5.5/manual.html#8.1
-    const wrapErrorObjects =
-        context.options.luaTarget === LuaTarget.Lua55 || context.options.luaTarget === LuaTarget.Universal;
+    // const wrapErrorObjects =
+    //     context.options.luaTarget === LuaTarget.Lua55 || context.options.luaTarget === LuaTarget.Universal;
+    const wrapErrorObjects = false;
     if (wrapErrorObjects) {
         importLuaLibFeature(context, LuaLibFeature.ErrorObject);
     }

--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -176,9 +176,8 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
     // preserve `throw undefined` semantics, route through xpcall with a message
     // handler that wraps nil into a sentinel, and unwrap before the user catch.
     // See: https://www.lua.org/manual/5.5/manual.html#8.1
-    // const wrapErrorObjects =
-    //     context.options.luaTarget === LuaTarget.Lua55 || context.options.luaTarget === LuaTarget.Universal;
-    const wrapErrorObjects = false;
+    const wrapErrorObjects =
+        context.options.luaTarget === LuaTarget.Lua55 || context.options.luaTarget === LuaTarget.Universal;
     if (wrapErrorObjects) {
         importLuaLibFeature(context, LuaLibFeature.ErrorObject);
     }

--- a/test/util.ts
+++ b/test/util.ts
@@ -42,11 +42,15 @@ function getLuaBindingsForVersion(target: tstl.LuaTarget): { lauxlib: LauxLib; l
         const { lauxlib, lua, lualib } = require("lua-wasm-bindings/dist/lua.53");
         return { lauxlib, lua, lualib };
     }
+    if (target === tstl.LuaTarget.Lua54) {
+        const { lauxlib, lua, lualib } = require("lua-wasm-bindings/dist/lua.54");
+        return { lauxlib, lua, lualib };
+    }
     if (target === tstl.LuaTarget.LuaJIT) {
         throw Error("Can't use executeLua() or expectToMatchJsResult() with LuaJIT as target!");
     }
 
-    const { lauxlib, lua, lualib } = require("lua-wasm-bindings/dist/lua.54");
+    const { lauxlib, lua, lualib } = require("lua-wasm-bindings/dist/lua.55");
     return { lauxlib, lua, lualib };
 }
 


### PR DESCRIPTION
Lua 5.5 changes:

- 8.1 Incompatibilities in the Language https://www.lua.org/manual/5.5/manual.html#8.1
- Error Handling https://www.lua.org/manual/5.5/manual.html#2.3

Related to #1676 but doesn't address any of the listed changes there. Note that this incompat is not listed in the issue or in the linked change list: https://www.lua.org/manual/5.5/readme.html#changes (although the change list does link to the incompat list)