### PR TITLE
Fix try/catch/finally flow

### DIFF
--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -165,6 +165,7 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
 
     const tryResultIdentifier = lua.createIdentifier("____try");
     const returnValueIdentifier = lua.createIdentifier("____returnValue");
+    const rethrowIdentifier = lua.createIdentifier("____rethrow");
 
     const result: lua.Statement[] = [];
 
@@ -191,6 +192,9 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
             }
         }
         result.push(lua.createVariableDeclarationStatement(tryReturnIdentifiers, tryCall));
+        if (statement.finallyBlock) {
+            result.push(lua.createVariableDeclarationStatement(rethrowIdentifier));
+        }
 
         const catchCall = lua.createCallExpression(
             catchIdentifier,
@@ -198,13 +202,26 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
         );
         const catchCallStatement = hasReturn
             ? lua.createAssignmentStatement(
-                  [lua.cloneIdentifier(returnedIdentifier), lua.cloneIdentifier(returnValueIdentifier)],
-                  catchCall
-              )
+                [lua.cloneIdentifier(returnedIdentifier), lua.cloneIdentifier(returnValueIdentifier)],
+                catchCall
+            )
             : lua.createExpressionStatement(catchCall);
 
+        const catchCallFunction = lua.createFunctionExpression(lua.createBlock([catchCallStatement]));
+
+        const tryCatchCall = lua.createCallExpression(pCall, [catchCallFunction]);
+
+        const tryCatchCallStatement = lua.createAssignmentStatement(
+            [lua.cloneIdentifier(tryResultIdentifier), lua.cloneIdentifier(rethrowIdentifier)],
+            tryCatchCall
+        );
+
         const notTryCondition = lua.createUnaryExpression(tryResultIdentifier, lua.SyntaxKind.NotOperator);
-        result.push(lua.createIfStatement(notTryCondition, lua.createBlock([catchCallStatement])));
+        result.push(lua.createIfStatement(notTryCondition, lua.createBlock(
+            statement.finallyBlock
+                ? [tryCatchCallStatement]
+                : [catchCallStatement]
+        )));
     } else if (tryScope.functionReturned) {
         // try with return, but no catch
         // returnedIdentifier = lua.createIdentifier("____returned");
@@ -230,21 +247,31 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
         result.push(...context.transformStatements(statement.finallyBlock));
     }
 
-    // Re-throw error if try had no catch but had a finally.
+    // Re-throw error if try had a finally.
     // On pcall failure the error is the second return value, which lands in
-    // ____hasReturned (when functionReturned) or ____error (otherwise).
-    if (!statement.catchClause && statement.finallyBlock) {
+    // ____hasReturned (when functionReturned), ____rethrow
+    // (catch throw/re-throw), or ____error (otherwise).
+    if (statement.finallyBlock) {
         const notTryCondition = lua.createUnaryExpression(
             lua.cloneIdentifier(tryResultIdentifier),
             lua.SyntaxKind.NotOperator
         );
-        const errorIdentifier = tryScope.functionReturned
-            ? lua.cloneIdentifier(returnedIdentifier)
-            : lua.createIdentifier("____error");
-        const rethrow = lua.createExpressionStatement(
-            lua.createCallExpression(lua.createIdentifier("error"), [errorIdentifier, lua.createNumericLiteral(0)])
-        );
-        result.push(lua.createIfStatement(notTryCondition, lua.createBlock([rethrow])));
+
+        if (!statement.catchClause) {
+            const errorIdentifier = tryScope.functionReturned
+                ? lua.cloneIdentifier(returnedIdentifier)
+                : lua.createIdentifier("____error");
+            const rethrow = lua.createExpressionStatement(
+                lua.createCallExpression(lua.createIdentifier("error"), [errorIdentifier, lua.createNumericLiteral(0)])
+            );
+            result.push(lua.createIfStatement(notTryCondition, lua.createBlock([rethrow])));
+        } else if (statement.catchClause.block.statements.length > 0) {
+            // Re-throw is possible only from non-empty blocks.
+            const rethrow = lua.createExpressionStatement(
+                lua.createCallExpression(lua.createIdentifier("error"), [rethrowIdentifier, lua.createNumericLiteral(0)])
+            );
+            result.push(lua.createIfStatement(notTryCondition, lua.createBlock([rethrow])));
+        }
     }
 
     if (returnCondition && returnedIdentifier) {

--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -202,9 +202,9 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
         );
         const catchCallStatement = hasReturn
             ? lua.createAssignmentStatement(
-                [lua.cloneIdentifier(returnedIdentifier), lua.cloneIdentifier(returnValueIdentifier)],
-                catchCall
-            )
+                  [lua.cloneIdentifier(returnedIdentifier), lua.cloneIdentifier(returnValueIdentifier)],
+                  catchCall
+              )
             : lua.createExpressionStatement(catchCall);
 
         const catchCallFunction = lua.createFunctionExpression(lua.createBlock([catchCallStatement]));
@@ -217,11 +217,12 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
         );
 
         const notTryCondition = lua.createUnaryExpression(tryResultIdentifier, lua.SyntaxKind.NotOperator);
-        result.push(lua.createIfStatement(notTryCondition, lua.createBlock(
-            statement.finallyBlock
-                ? [tryCatchCallStatement]
-                : [catchCallStatement]
-        )));
+        result.push(
+            lua.createIfStatement(
+                notTryCondition,
+                lua.createBlock(statement.finallyBlock ? [tryCatchCallStatement] : [catchCallStatement])
+            )
+        );
     } else if (tryScope.functionReturned) {
         // try with return, but no catch
         // returnedIdentifier = lua.createIdentifier("____returned");
@@ -267,7 +268,10 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
         } else if (statement.catchClause.block.statements.length > 0) {
             // Re-throw is possible only from non-empty blocks.
             const rethrow = lua.createExpressionStatement(
-                lua.createCallExpression(lua.createIdentifier("error"), [rethrowIdentifier, lua.createNumericLiteral(0)])
+                lua.createCallExpression(lua.createIdentifier("error"), [
+                    rethrowIdentifier,
+                    lua.createNumericLiteral(0),
+                ])
             );
             result.push(lua.createIfStatement(notTryCondition, lua.createBlock([rethrow])));
         }

--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -249,8 +249,7 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
 
     // Re-throw error if try had a finally.
     // On pcall failure the error is the second return value, which lands in
-    // ____hasReturned (when functionReturned), ____rethrow
-    // (catch throw/re-throw), or ____error (otherwise).
+    // ____hasReturned (when functionReturned) or ____error (otherwise).
     if (statement.finallyBlock) {
         const notTryCondition = lua.createUnaryExpression(
             lua.cloneIdentifier(tryResultIdentifier),

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -7,31 +7,40 @@ test("throwString", () => {
     `.expectToEqual(new util.ExecutionError("Some Error"));
 });
 
-// TODO: Finally does not behave like it should, see #1137
-// eslint-disable-next-line jest/no-disabled-tests
-test.skip.each([0, 1, 2])("re-throw (%p)", i => {
+test.each([
+    { innerTry: false, innerFinally: false, outerFinally: false },
+    { innerTry: false, innerFinally: false, outerFinally: true },
+    { innerTry: false, innerFinally: true, outerFinally: false },
+    { innerTry: false, innerFinally: true, outerFinally: true },
+    { innerTry: true, innerFinally: false, outerFinally: false },
+    { innerTry: true, innerFinally: false, outerFinally: true },
+    { innerTry: true, innerFinally: true, outerFinally: false },
+    { innerTry: true, innerFinally: true, outerFinally: true },
+])("re-throw (%j)", o => {
     util.testFunction`
-        const i: number = ${i};
+        const innerTry: boolean = ${o.innerTry};
+        const innerFinally: boolean = ${o.innerFinally};
+        const outerFinally: boolean = ${o.outerFinally};
         function foo() {
             try {
                 try {
-                    if (i === 0) { throw "z"; }
+                    if (innerTry) { throw "inner.try"; }
                 } catch (e) {
-                    throw "a";
+                    throw (e as string) + "->" + "inner.catch";
                 } finally {
-                    if (i === 1) { throw "b"; }
+                    if (innerFinally) { throw "inner.finally"; }
                 }
             } catch (e) {
-                throw (e as string).toUpperCase();
+                throw (e as string) + "->" + "outer.catch";
             } finally {
-                throw "C";
+                if (outerFinally) { throw "outer.finally"; }
             }
         }
         let result: string = "x";
         try {
             foo();
         } catch (e) {
-            result = (e as string)[(e as string).length - 1];
+            result = e as string;
         }
         return result;
     `.expectToMatchJsResult();


### PR DESCRIPTION
## TL;DR

This PR fixes the issue described in #1137.

`try/catch/finally` blocks didn't behave correctly when the catch block threw (or re-threw) an error. The finally block would never execute because the error from catch propagated immediately.

**Example**:

<table>
<thead>
<tr><th>Input</th><th>Output (-before, +after)</th></tr>
<thead>

<tbody>
<tr>

<td>

```typescript
declare function compute(this: void): void

function foo() {
    try {
        compute()
    } catch (err) {
        print("Reporting the error ...")
        throw err;
    } finally {
        print("Cleaning up resources...")
    }
}
```

</td>

<td>

```diff
 function foo(self)
     do
         local function ____catch(err)
             print("Reporting the error ...")
             error(err, 0)
         end
         local ____try, ____hasReturned = pcall(function()
             compute()
         end)
+        local ____rethrow
         if not ____try then
-            ____catch(____hasReturned)
+            ____try, ____rethrow = pcall(function()
+                ____catch(____hasReturned)
+            end)
         end
         do
             print("Cleaning up resources...")
         end
+        if not ____try then
+            error(____rethrow, 0)
+        end
     end
 end

```

</td>

</tr>
</tbody>
</table>

**Logs (-before, +after)**

```diff
 Reporting the error ...
+Cleaning up resources...
 stdin:8: attempt to call global 'compute' (a nil value)
 stack traceback:
 	[C]: in function 'error'
-	stdin:5: in function '____catch'
-	stdin:11: in function 'foo'
+	stdin:20: in function 'foo'
 	stdin:1: in main chunk
```


## How the fix works

**Note**: This change only affects `try/catch/finally` blocks. `try/catch` and `try/finally` are unchanged.

We capture any errors from `catch` block  into a `____rethrow` variable, then let the `finally` execute, and only then re-throw the error.

## A few more examples

<details>
<summary>From unit tests (was broken) ("re-throw (%p)")</summary>

```diff
--- ./testdata-old/testcase-0002.lua
+++ ./testdata/testcase-0002.lua
@@ -1,55 +1,67 @@
 local ____exports = {}
 function ____exports.__main(self)
     local innerTry = false
     local innerFinally = false
     local outerFinally = false
     local function foo(self)
         do
             local function ____catch(e)
                 error((e .. "->") .. "outer.catch", 0)
             end
             local ____try, ____hasReturned = pcall(function()
                 do
                     local function ____catch(e)
                         error((e .. "->") .. "inner.catch", 0)
                     end
                     local ____try, ____hasReturned = pcall(function()
                         if innerTry then
                             error("inner.try", 0)
                         end
                     end)
+                    local ____rethrow
                     if not ____try then
-                        ____catch(____hasReturned)
+                        ____try, ____rethrow = pcall(function()
+                            ____catch(____hasReturned)
+                        end)
                     end
                     do
                         if innerFinally then
                             error("inner.finally", 0)
                         end
                     end
+                    if not ____try then
+                        error(____rethrow, 0)
+                    end
                 end
             end)
+            local ____rethrow
             if not ____try then
-                ____catch(____hasReturned)
+                ____try, ____rethrow = pcall(function()
+                    ____catch(____hasReturned)
+                end)
             end
             do
                 if outerFinally then
                     error("outer.finally", 0)
                 end
             end
+            if not ____try then
+                error(____rethrow, 0)
+            end
         end
     end
     local result = "x"
     do
         local function ____catch(e)
             result = e
         end
         local ____try, ____hasReturned = pcall(function()
             foo(nil)
         end)
         if not ____try then
             ____catch(____hasReturned)
         end
     end
     return result
 end
 return ____exports
```

</details>

<details>
<summary>From unit tests ("return from catch->finally")</summary>

```diff
--- ./testdata-old/testcase-0020.lua
+++ ./testdata/testcase-0020.lua
@@ -1,29 +1,35 @@
 local ____exports = {}
 function ____exports.__main(self)
     local x = "unevaluated"
     local function evaluate(self, arg)
         x = "evaluated"
         return arg
     end
     local function foobar(self)
         do
             local function ____catch(e)
                 return true, evaluate(nil, e)
             end
             local ____try, ____hasReturned, ____returnValue = pcall(function()
                 error("foobar", 0)
             end)
+            local ____rethrow
             if not ____try then
-                ____hasReturned, ____returnValue = ____catch(____hasReturned)
+                ____try, ____rethrow = pcall(function()
+                    ____hasReturned, ____returnValue = ____catch(____hasReturned)
+                end)
             end
             do
                 return "finally"
             end
+            if not ____try then
+                error(____rethrow, 0)
+            end
             if ____hasReturned then
                 return ____returnValue
             end
         end
     end
     return (tostring(foobar(nil)) .. " ") .. x
 end
 return ____exports
```

</details>

## Resources
Closes: #1137